### PR TITLE
Rename package to swift-otel

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: SwiftDocOrg/swift-doc@master
         with:
           format: html
-          base-url: /opentelemetry-swift/
+          base-url: /swift-otel/
           module-name: "OpenTelemetry Swift"
           output: Documentation
 

--- a/Examples/Onboarding/Package.resolved
+++ b/Examples/Onboarding/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-distributed-tracing.git",
         "state": {
           "branch": null,
-          "revision": "7a89c904d80fd2dc7c6071806f38d5d0b2d5a1b5",
-          "version": "0.2.0"
+          "revision": "6173049f396771a35e82f6a19b6f63b5cedc4603",
+          "version": "0.3.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-distributed-tracing-baggage.git",
         "state": {
           "branch": null,
-          "revision": "c8457ce61adc6a3b9e6223ca147f5196f99e22cc",
-          "version": "0.2.3"
+          "revision": "05f21f55bc5b3f71f6c8a986025c0d0c40c9eed2",
+          "version": "0.3.0"
         }
       },
       {

--- a/Examples/Onboarding/Package.swift
+++ b/Examples/Onboarding/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     ],
     targets: [
         .target(name: "Onboarding", dependencies: [
-            .product(name: "OpenTelemetry", package: "opentelemetry-swift"),
-            .product(name: "OtlpGRPCSpanExporting", package: "opentelemetry-swift"),
+            .product(name: "OpenTelemetry", package: "swift-otel"),
+            .product(name: "OtlpGRPCSpanExporting", package: "swift-otel"),
         ]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "opentelemetry-swift",
+    name: "swift-otel",
     platforms: [
         .iOS(.v11),
         .macOS(.v10_13),

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Swift 5.3](https://img.shields.io/badge/Swift-5.3-%23f05137)](https://swift.org)
 [![Swift 5.4](https://img.shields.io/badge/Swift-5.4-%23f05137)](https://swift.org)
 [![Swift 5.5](https://img.shields.io/badge/Swift-5.5-%23f05137)](https://swift.org)
-[![CI](https://github.com/slashmo/opentelemetry-swift/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/slashmo/opentelemetry-swift/actions/workflows/ci.yaml)
+[![CI](https://github.com/slashmo/swift-otel/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/slashmo/swift-otel/actions/workflows/ci.yaml)
 
 [![Made for Swift Distributed Tracing](https://img.shields.io/badge/Made%20for-Swift%20Distributed%20Tracing-%23f05137)](https://github.com/apple/swift-distributed-tracing)
 
@@ -29,13 +29,13 @@ a trace created by "onboarding":
 To add "OpenTelemetry Swift" to our project, we first need to include it as a package dependency:
 
 ```swift
-.package(url: "https://github.com/slashmo/opentelemetry-swift.git", from: "0.3.0"),
+.package(url: "https://github.com/slashmo/swift-otel.git", from: "0.3.0"),
 ```
 
 Then we add `OpenTelemetry` to our executable target:
 
 ```swift
-.product(name: "OpenTelemetry", package: "opentelemetry-swift"),
+.product(name: "OpenTelemetry", package: "swift-otel"),
 ```
 
 ### Bootstrapping
@@ -98,7 +98,7 @@ After a couple of seconds everything should be up-and-running. Let's go ahead an
 `Package.swift`:
 
 ```swift
-.product(name: "OtlpGRPCSpanExporting", package: "opentelemetry-swift"),
+.product(name: "OtlpGRPCSpanExporting", package: "swift-otel"),
 ```
 
 On to the fun part - Configuring the `OtlpGRPCSpanExporter`:
@@ -189,8 +189,8 @@ A ["W3C TraceContext"](https://www.w3.org/TR/2020/REC-trace-context-1-20200206/)
 for this by default. As the name suggests, it generates completely random IDs.
 
 Some tracing systems require IDs in a slightly different format.
-[`XRayIDGenerator`](https://slashmo.github.io/opentelemetry-swift-xray/XRayIDGenerator/) from the [X-Ray compatibility
-library](https://github.com/slashmo/opentelemetry-swift-xray) e.g. will include the current timestamp at the start of
+[`XRayIDGenerator`](https://slashmo.github.io/swift-otel-xray/XRayIDGenerator/) from the [X-Ray compatibility
+library](https://github.com/slashmo/swift-otel-xray) e.g. will include the current timestamp at the start of
 each generated trace ID.
 
 To create your own ID generator you need to implement the `OTelIDGenerator` protocol.
@@ -209,16 +209,16 @@ let otel = OTel(
 
 #### Resources 🔗
 
-- [📖 API Docs: OTelIDGenerator](https://slashmo.github.io/opentelemetry-swift/OTelIDGenerator/)
+- [📖 API Docs: OTelIDGenerator](https://slashmo.github.io/swift-otel/OTelIDGenerator/)
 - [📖 OpenTelemetry Specification: ID Generator](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#id-generators)
-- [🧩 AWS X-Ray support library](https://github.com/slashmo/opentelemetry-swift-xray)
+- [🧩 AWS X-Ray support library](https://github.com/slashmo/swift-otel-xray)
 
 ### Sampling
 
 If your application creates a large amount of spans you might want to look into sampling out certain spans. By default,
 "OpenTelemetry Swift" ships with a
-"[parent-based](https://slashmo.github.io/opentelemetry-swift/OTel_ParentBasedSampler/)" sampler, configured to always
-sample root spans using a "[constant sampler](https://slashmo.github.io/opentelemetry-swift/OTel_ConstantSampler/)".
+"[parent-based](https://slashmo.github.io/swift-otel/OTel_ParentBasedSampler/)" sampler, configured to always
+sample root spans using a "[constant sampler](https://slashmo.github.io/swift-otel/OTel_ConstantSampler/)".
 Parent-based means that this sampler takes into account whether the parent span was sampled.
 
 To create your own sampler you need to implement the `OTelSampler` protocol.
@@ -239,9 +239,9 @@ let otel = OTel(
 
 #### Resources 🔗
 
-- [📖 API Docs: OTelSampler](https://slashmo.github.io/opentelemetry-swift/OTelSampler/)
-- [📖 API Docs: OTel.ParentBasedSampler](https://slashmo.github.io/opentelemetry-swift/OTel_ParentBasedSampler/)
-- [📖 API Docs: OTel.ConstantSampler](https://slashmo.github.io/opentelemetry-swift/OTel_ConstantSampler/)
+- [📖 API Docs: OTelSampler](https://slashmo.github.io/swift-otel/OTelSampler/)
+- [📖 API Docs: OTel.ParentBasedSampler](https://slashmo.github.io/swift-otel/OTel_ParentBasedSampler/)
+- [📖 API Docs: OTel.ConstantSampler](https://slashmo.github.io/swift-otel/OTel_ConstantSampler/)
 - [📖 OpenTelemetry Specification: Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampling)
 
 ### Processing ended spans
@@ -265,8 +265,8 @@ let otel = OTel(
 
 #### Resources 🔗
 
-- [📖 API Docs: OTelSpanProcessor](https://slashmo.github.io/opentelemetry-swift/OTelSpanProcessor/)
-- [📖 API Docs: OTel.SimpleSpanProcessor](https://slashmo.github.io/opentelemetry-swift/OTel_SimpleSpanProcessor/)
+- [📖 API Docs: OTelSpanProcessor](https://slashmo.github.io/swift-otel/OTelSpanProcessor/)
+- [📖 API Docs: OTel.SimpleSpanProcessor](https://slashmo.github.io/swift-otel/OTel_SimpleSpanProcessor/)
 - [📖 OpenTelemetry Specification: Span Processor](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-processor)
 
 ### Exporting processed spans
@@ -296,8 +296,8 @@ let otel = OTel(
 
 #### Resources 🔗
 
-- [📖 API Docs: OTelSpanExporter](https://slashmo.github.io/opentelemetry-swift/OTelSpanExporter/)
-- [📖 API Docs: OtlpGRPCSpanExporter](https://slashmo.github.io/opentelemetry-swift/OtlpGRPCSpanExporter/)
+- [📖 API Docs: OTelSpanExporter](https://slashmo.github.io/swift-otel/OTelSpanExporter/)
+- [📖 API Docs: OtlpGRPCSpanExporter](https://slashmo.github.io/swift-otel/OtlpGRPCSpanExporter/)
 - [📖 OpenTelemetry Collector](https://opentelemetry.io/docs/collector)
 - [📖 OpenTelemetry Specification: Span Exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-exporter)
 
@@ -306,7 +306,7 @@ let otel = OTel(
 OpenTelemetry uses the [W3C TraceContext format](https://www.w3.org/TR/2020/REC-trace-context-1-20200206/) to propagate
 span context across HTTP requests by default. Some tracing backends may not fully support this standard and need to use
 a custom propagator. X-Ray e.g. propagates using the `X-Amzn-Trace-Id` header. Support for this header is implemented
-in the [X-Ray support library](https://github.com/slashmo/opentelemetry-swift-xray).
+in the [X-Ray support library](https://github.com/slashmo/swift-otel-xray).
 
 To create your own propagator you need to implement the `OTelPropagator` protocol.
 
@@ -324,8 +324,8 @@ let otel = OTel(
 
 #### Resources 🔗
 
-- [📖 API Docs: OTelPropagator](https://slashmo.github.io/opentelemetry-swift/OTelPropagator/)
-- [📖 API Docs: W3CPropagator](https://slashmo.github.io/opentelemetry-swift/OTel_W3CPropagator/)
+- [📖 API Docs: OTelPropagator](https://slashmo.github.io/swift-otel/OTelPropagator/)
+- [📖 API Docs: W3CPropagator](https://slashmo.github.io/swift-otel/OTel_W3CPropagator/)
 - [📖 OpenTelemetry Specification: Propagators API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md)
 
 ### Detecting resource information
@@ -370,8 +370,8 @@ OTel.ResourceDetection.none
 
 #### Resources 🔗
 
-- [📖 API Docs: OTelResourceDetector](https://slashmo.github.io/opentelemetry-swift/OTelResourceDetector/)
-- [📖 API Docs: OTelResourceDetection](https://slashmo.github.io/opentelemetry-swift/OTel_ResourceDetection/)
+- [📖 API Docs: OTelResourceDetector](https://slashmo.github.io/swift-otel/OTelResourceDetector/)
+- [📖 API Docs: OTelResourceDetection](https://slashmo.github.io/swift-otel/OTel_ResourceDetection/)
 - [📖 OpenTelemetry Specification: Resource](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md)
 
 ## Development

--- a/Sources/OtlpGRPCSpanExporting/TypeConversion/InstrumentationLibrarySpans+Proto.swift
+++ b/Sources/OtlpGRPCSpanExporting/TypeConversion/InstrumentationLibrarySpans+Proto.swift
@@ -17,7 +17,7 @@ extension Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans {
     init<C: Collection>(spans: C) where C.Element == OTel.RecordedSpan {
         self = .with {
             $0.instrumentationLibrary = .with { library in
-                library.name = "opentelemetry-swift"
+                library.name = "swift-otel"
                 library.version = OTel.versionString
             }
             $0.spans = spans.map(Opentelemetry_Proto_Trace_V1_Span.init)

--- a/Tests/OtlpGRPCSpanExportingTests/TypeConversionTests.swift
+++ b/Tests/OtlpGRPCSpanExportingTests/TypeConversionTests.swift
@@ -100,7 +100,7 @@ final class TypeConversionTests: XCTestCase {
             Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans(spans: [span]),
             .with {
                 $0.instrumentationLibrary = .with { library in
-                    library.name = "opentelemetry-swift"
+                    library.name = "swift-otel"
                     library.version = OTel.versionString
                 }
                 $0.spans = [.init(span)]

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -35,7 +35,7 @@ function replace_acceptable_years() {
 }
 
 printf "=> Checking license headers\n"
-tmp=$(mktemp /tmp/.opentelemetry-swift-soundness_XXXXXX)
+tmp=$(mktemp /tmp/.swift-otel-soundness_XXXXXX)
 
 for language in swift-or-c bash dtrace; do
   printf "   * $language... "


### PR DESCRIPTION
Having the same name as the official opentelemetry-swift problem caused some confusion so we'll rename this one to `swift-otel`.