### PR TITLE
Use NIOLock instead of NIO.Lock

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.1"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.43.0"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/OpenTelemetry/Processing/BatchSpanProcessor.swift
+++ b/Sources/OpenTelemetry/Processing/BatchSpanProcessor.swift
@@ -25,7 +25,7 @@ extension OTel {
         private let maxBatchSize: Int
 
         private var queue = CircularBuffer<OTel.RecordedSpan>()
-        private let queueLock = Lock()
+        private let queueLock = NIOLock()
         private var exportTask: RepeatedTask!
 
         /// Initialize a batch span processor.

--- a/Sources/OpenTelemetry/Tracer.swift
+++ b/Sources/OpenTelemetry/Tracer.swift
@@ -149,7 +149,7 @@ extension OTel.Tracer {
         let resource: OTel.Resource
 
         private let logger: Logger
-        private let lock = Lock()
+        private let lock = NIOLock()
 
         private let onEnd: (OTel.RecordedSpan) -> Void
 

--- a/Tests/OpenTelemetryTests/Helpers/InMemorySpanExporter.swift
+++ b/Tests/OpenTelemetryTests/Helpers/InMemorySpanExporter.swift
@@ -17,7 +17,7 @@ import OpenTelemetry
 
 final class InMemorySpanExporter: OTelSpanExporter {
     private let eventLoopGroup: EventLoopGroup
-    private let lock = Lock()
+    private let lock = NIOLock()
     private var _spans = [OTel.RecordedSpan]()
     private(set) var numberOfExports = 0
 


### PR DESCRIPTION
- Use `NIOLock` instead of `NIO.Lock`
- Require at least [`2.42.1`](https://github.com/apple/swift-nio/releases/tag/2.42.0) of NIO which introduced `NIOLock`

See Also: https://github.com/apple/swift-nio/pull/2266