### PR TITLE
[CI] Configure dependabot updates for actions 📦

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "slashmo"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,9 @@ jobs:
     container: ${{ matrix.images }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
       - name: Cache Swift PM
-        uses: actions/cache@v2
+        uses: actions/cache@v3.3.0
         with:
           path: .build
           key: ${{ runner.os }}-${{ matrix.images }}-spm-${{ hashFiles('Package.swift') }}
@@ -37,7 +37,7 @@ jobs:
         working-directory: ./Examples/Onboarding
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
       - name: Install Swift
         uses: slashmo/install-swift@v0.4.0
         with:


### PR DESCRIPTION
- set up dependabot to update actions
- use latest versions of `actions/checkout` and `actions/cache`