### PR TITLE
Bump minimum Swift version to 5.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,12 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         images:
-          - swift:5.3
-          - swift:5.4
-          - swift:5.5
-          - swift:5.6
           - swift:5.7
-          - swiftlang/swift:nightly-master
+          - swiftlang/swift:nightly-main-focal
     container: ${{ matrix.images }}
     steps:
       - name: Checkout

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 # file options
 
---swiftversion 5.3
+--swiftversion 5.7
 --exclude **/.build
 
 # format options

--- a/Examples/Onboarding/Package.swift
+++ b/Examples/Onboarding/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # OpenTelemetry for Swift
 
-[![Swift 5.3](https://img.shields.io/badge/Swift-5.3-%23f05137)](https://swift.org)
-[![Swift 5.4](https://img.shields.io/badge/Swift-5.4-%23f05137)](https://swift.org)
-[![Swift 5.5](https://img.shields.io/badge/Swift-5.5-%23f05137)](https://swift.org)
+[![Swift 5.7](https://img.shields.io/badge/Swift-5.7-%23f05137)](https://swift.org)
 [![CI](https://github.com/slashmo/swift-otel/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/slashmo/swift-otel/actions/workflows/ci.yaml)
 
 [![Made for Swift Distributed Tracing](https://img.shields.io/badge/Made%20for-Swift%20Distributed%20Tracing-%23f05137)](https://github.com/apple/swift-distributed-tracing)

--- a/Sources/OpenTelemetry/Logging/MetadataProvider+OTel.swift
+++ b/Sources/OpenTelemetry/Logging/MetadataProvider+OTel.swift
@@ -14,7 +14,6 @@
 import InstrumentationBaggage
 import Logging
 
-#if swift(>=5.5) && canImport(_Concurrency)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension Logger.MetadataProvider {
     /// A metadata provider exposing the current trace and span ID.
@@ -36,4 +35,3 @@ extension Logger.MetadataProvider {
     /// A metadata provider exposing the current trace and span ID.
     public static let otel = Logger.MetadataProvider.otel()
 }
-#endif

--- a/Sources/OpenTelemetry/SpanContext/SpanContext.swift
+++ b/Sources/OpenTelemetry/SpanContext/SpanContext.swift
@@ -64,6 +64,4 @@ extension OTel {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 extension OTel.SpanContext: Sendable {}
-#endif

--- a/Sources/OpenTelemetry/SpanContext/SpanID.swift
+++ b/Sources/OpenTelemetry/SpanContext/SpanID.swift
@@ -91,6 +91,4 @@ extension OTel.SpanID: Hashable {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 extension OTel.SpanID: Sendable {}
-#endif

--- a/Sources/OpenTelemetry/SpanContext/TraceFlags.swift
+++ b/Sources/OpenTelemetry/SpanContext/TraceFlags.swift
@@ -33,6 +33,4 @@ extension OTel {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 extension OTel.TraceFlags: Sendable {}
-#endif

--- a/Sources/OpenTelemetry/SpanContext/TraceID.swift
+++ b/Sources/OpenTelemetry/SpanContext/TraceID.swift
@@ -126,6 +126,4 @@ extension OTel.TraceID: Hashable {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 extension OTel.TraceID: Sendable {}
-#endif

--- a/Sources/OpenTelemetry/SpanContext/TraceState.swift
+++ b/Sources/OpenTelemetry/SpanContext/TraceState.swift
@@ -45,6 +45,4 @@ extension OTel.TraceState: CustomStringConvertible {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 extension OTel.TraceState: Sendable {}
-#endif

--- a/Tests/OpenTelemetryTests/Logging/MetadataProviderTests.swift
+++ b/Tests/OpenTelemetryTests/Logging/MetadataProviderTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 final class MetadataProviderTests: XCTestCase {
     func test_providesMetadataFromSpanContext_withDefaultLabels() throws {
-        #if swift(>=5.5) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else {
             throw XCTSkip("Task locals are not supported on this platform.")
         }
@@ -47,11 +46,9 @@ final class MetadataProviderTests: XCTestCase {
         XCTAssertTrue(message.contains("trace-id=\(spanContext.traceID)"))
         XCTAssertTrue(message.contains("explicit=42"))
         XCTAssertTrue(message.contains("This is a test message"))
-        #endif
     }
 
     func test_providesMetadataFromSpanContext_withCustomLabels() throws {
-        #if swift(>=5.5) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else {
             throw XCTSkip("Task locals are not supported on this platform.")
         }
@@ -81,11 +78,9 @@ final class MetadataProviderTests: XCTestCase {
         XCTAssertTrue(message.contains("custom_trace_id=\(spanContext.traceID)"))
         XCTAssertTrue(message.contains("explicit=42"))
         XCTAssertTrue(message.contains("This is a test message"))
-        #endif
     }
 
     func test_doesNotProvideMetadataWithoutSpanContext() throws {
-        #if swift(>=5.5) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else {
             throw XCTSkip("Task locals are not supported on this platform.")
         }
@@ -104,7 +99,6 @@ final class MetadataProviderTests: XCTestCase {
         XCTAssertFalse(message.contains("span-id"))
         XCTAssertTrue(message.contains("explicit=42"))
         XCTAssertTrue(message.contains("This is a test message"))
-        #endif
     }
 }
 
@@ -118,6 +112,4 @@ final class InterceptingStream: TextOutputStream {
     }
 }
 
-#if compiler(>=5.6)
 extension InterceptingStream: @unchecked Sendable {}
-#endif


### PR DESCRIPTION
In preparation for the upcoming `swift-distributed-tracing` 1.0 release we bump the minimum Swift version to 5.7.