### PR TITLE
Add HTTP server example with Hummingbird middleware

### DIFF
--- a/Examples/Server/Package.swift
+++ b/Examples/Server/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-otel-server-example",
+    platforms: [
+        .macOS(.v14),
+    ],
+    dependencies: [
+        .package(name: "swift-otel", path: "../.."),
+        .package(url: "https://github.com/hummingbird-project/hummingbird", exact: "2.0.0-alpha.1"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "ServerExample",
+            dependencies: [
+                .product(name: "OTel", package: "swift-otel"),
+                .product(name: "OTLPGRPC", package: "swift-otel"),
+                .product(name: "Hummingbird", package: "hummingbird"),
+            ]
+        )
+    ]
+)

--- a/Examples/Server/Package.swift
+++ b/Examples/Server/Package.swift
@@ -19,6 +19,6 @@ let package = Package(
                 .product(name: "OTLPGRPC", package: "swift-otel"),
                 .product(name: "Hummingbird", package: "hummingbird"),
             ]
-        )
+        ),
     ]
 )

--- a/Examples/Server/README.md
+++ b/Examples/Server/README.md
@@ -1,0 +1,88 @@
+# HTTP Server Example
+
+An HTTP server that uses middleware to emit traces for each HTTP request.
+
+> **Disclaimer:** This example is deliberately simplified and is intended for
+> illustrative purposes only.
+
+## Overview
+
+This example package configures and starts a Hummingbird HTTP server along with
+its associated middleware for instrumentation.
+
+## Testing
+
+The example uses [Compose](https://docs.docker.com/compose) to run a set of
+containers to collect and visualize the traces from the server, which is
+running on your local machine.
+
+```none
+┌─────────────────────────────────────────────────────────────────────┐
+│                                                                 Host│
+│                       ┌────────────────────────────────────────────┐│
+│                       │                              Docker Compose││
+│ ┌────────┐            │ ┌───────────┐                              ││
+│ │        │            │ │           │               ┌────────────┐ ││
+│ │  HTTP  │            │ │   OTel    │               │            │ ││
+│ │ server │─OTLP/gRPC──┼▶│ Collector │─OTLP/gRPC────▶│   Jaeger   │ ││
+│ │        │            │ │           │               │            │ ││
+│ └────────┘            │ └───────────┘               └────────────┘ ││
+│      ▲       ┌──────┐ └────────────────────────────────────────────┘│
+│      └───────│ curl │                                               │
+│   GET /hello └──────┘                                               │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+The server sends requests to OTel Collector, which is configured with an OTLP
+receiver and a Jaeger exporter. The Collector is also configured with a debug
+exporter so we can see the events it receives in the container logs.
+
+### Running the collector and visualization containers
+
+In one terminal window, run the following command:
+
+```console
+% docker compose -f docker/docker-compose.yaml up
+[+] Running 2/2
+ ✔ Container docker-jaeger-1          Created                       0.5s
+ ✔ Container docker-otel-collector-1  Created                       0.5s
+...
+```
+
+At this point the tracing collector and visualization tools are running.
+
+### Running the server
+
+Now, in another terminal, run the server locally using the following command:
+
+```console
+% swift run
+```
+
+### Making some requests
+
+Finally, in a third terminal, make a few requests to the server:
+
+```console
+% for i in {1..5}; do curl localhost:8080/hello; done
+hello
+hello
+hello
+hello
+hello
+```
+
+You should see log messages from the server for each request and each log line
+should include an OTel `trace_id` field.
+
+### Visualizing the traces using Jaeger UI
+
+Visit Jaeger UI in your browser at [localhost:16686](http://localhost:16686).
+
+Select `HelloWorldServer` from the dropdown and click `Find Traces`, or use
+[this pre-canned link](http://localhost:16686/search?service=example_server).
+
+See the traces for the recent requests and click to select a trace for a given request.
+
+Click to expand the trace, the metadata associated with the request and the
+process, and the events.

--- a/Examples/Server/README.md
+++ b/Examples/Server/README.md
@@ -79,7 +79,7 @@ should include an OTel `trace_id` field.
 
 Visit Jaeger UI in your browser at [localhost:16686](http://localhost:16686).
 
-Select `HelloWorldServer` from the dropdown and click `Find Traces`, or use
+Select `example_server` from the dropdown and click `Find Traces`, or use
 [this pre-canned link](http://localhost:16686/search?service=example_server).
 
 See the traces for the recent requests and click to select a trace for a given request.

--- a/Examples/Server/Sources/ServerExample/ServerExample.swift
+++ b/Examples/Server/Sources/ServerExample/ServerExample.swift
@@ -29,7 +29,7 @@ enum ServerMiddlewareExample {
             return handler
         }
 
-        // Configure OTel resource detection to apply attributes to automatically apply helpful attributes to events.
+        // Configure OTel resource detection to automatically apply helpful attributes to events.
         let environment = OTelEnvironment.detected()
         let resourceDetection = OTelResourceDetection(detectors: [
             OTelProcessResourceDetector(),

--- a/Examples/Server/Sources/ServerExample/ServerExample.swift
+++ b/Examples/Server/Sources/ServerExample/ServerExample.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+import Logging
+import NIO
+import OTel
+import OTLPGRPC
+import ServiceLifecycle
+import Tracing
+
+@main
+enum ServerMiddlewareExample {
+    static func main() async throws {
+        // Bootstrap the logging backend with the OTel metadata provider which includes span IDs in logging messages.
+        LoggingSystem.bootstrap { label in
+            var handler = StreamLogHandler.standardError(label: label, metadataProvider: .otel)
+            handler.logLevel = .trace
+            return handler
+        }
+
+        // Configure OTel resource detection to apply attributes to automatically apply helpful attributes to events.
+        let environment = OTelEnvironment.detected()
+        let resourceDetection = OTelResourceDetection(detectors: [
+            OTelProcessResourceDetector(),
+            OTelEnvironmentResourceDetector(environment: environment),
+            .manual(OTelResource(attributes: ["service.name": "example_server"])),
+        ])
+        let resource = await resourceDetection.resource(environment: environment, logLevel: .trace)
+
+        // Bootstrap the tracing backend to export traces periodically in OTLP/gRPC.
+        let exporter = try OTLPGRPCSpanExporter(configuration: .init(environment: environment), group: MultiThreadedEventLoopGroup.singleton)
+        let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(environment: environment))
+        let tracer = OTelTracer(
+            idGenerator: OTelRandomIDGenerator(),
+            sampler: OTelConstantSampler(isOn: true),
+            propagator: OTelW3CPropagator(),
+            processor: processor,
+            environment: environment,
+            resource: resource
+        )
+        InstrumentationSystem.bootstrap(tracer)
+
+        // Create an HTTP server with instrumentation middleware and a simple /hello endpoint, on 127.0.0.1:8080.
+        let router = HBRouter()
+        router.middlewares.add(HBTracingMiddleware())
+        router.middlewares.add(HBLogRequestsMiddleware(.info))
+        router.get("hello") { request, context  in "hello" }
+        var app = HBApplication(router: router)
+
+        // Add the tracer lifecycle service to the HTTP server service group and start the application.
+        app.addServices(tracer)
+        try await app.runService()
+    }
+}

--- a/Examples/Server/Sources/ServerExample/ServerExample.swift
+++ b/Examples/Server/Sources/ServerExample/ServerExample.swift
@@ -54,7 +54,7 @@ enum ServerMiddlewareExample {
         let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware())
         router.middlewares.add(HBLogRequestsMiddleware(.info))
-        router.get("hello") { request, context  in "hello" }
+        router.get("hello") { _, _ in "hello" }
         var app = HBApplication(router: router)
 
         // Add the tracer lifecycle service to the HTTP server service group and start the application.

--- a/Examples/Server/Sources/ServerExample/ServerExample.swift
+++ b/Examples/Server/Sources/ServerExample/ServerExample.swift
@@ -13,7 +13,6 @@
 
 import Hummingbird
 import Logging
-import NIO
 import OTel
 import OTLPGRPC
 import ServiceLifecycle
@@ -39,7 +38,7 @@ enum ServerMiddlewareExample {
         let resource = await resourceDetection.resource(environment: environment, logLevel: .trace)
 
         // Bootstrap the tracing backend to export traces periodically in OTLP/gRPC.
-        let exporter = try OTLPGRPCSpanExporter(configuration: .init(environment: environment), group: MultiThreadedEventLoopGroup.singleton)
+        let exporter = try OTLPGRPCSpanExporter(configuration: .init(environment: environment))
         let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(environment: environment))
         let tracer = OTelTracer(
             idGenerator: OTelRandomIDGenerator(),

--- a/Examples/Server/docker/docker-compose.yaml
+++ b/Examples/Server/docker/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3.5"
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317"  # OTLP gRPC receiver
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - "16686:16686"  # Jaeger Web UI
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json

--- a/Examples/Server/docker/otel-collector-config.yaml
+++ b/Examples/Server/docker/otel-collector-config.yaml
@@ -4,9 +4,6 @@ receivers:
       grpc:
         endpoint: "otel-collector:4317"
 
-processors:
-  batch: {}
-
 exporters:
   debug:  # Data sources: traces, metrics, logs
     verbosity: detailed
@@ -20,7 +17,6 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
       exporters: [otlp/jaeger, debug]
 
 # yaml-language-server: $schema=https://raw.githubusercontent.com/srikanthccv/otelcol-jsonschema/main/schema.json

--- a/Examples/Server/docker/otel-collector-config.yaml
+++ b/Examples/Server/docker/otel-collector-config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "otel-collector:4317"
+
+processors:
+  batch: {}
+
+exporters:
+  debug:  # Data sources: traces, metrics, logs
+    verbosity: detailed
+
+  otlp/jaeger:  # Data sources: traces
+    endpoint: "jaeger:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/jaeger, debug]
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/srikanthccv/otelcol-jsonschema/main/schema.json

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -31,7 +31,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
   # this needs to replace all acceptable forms with 'YEARS'
-  sed -e 's/202[3]/YEARS/'
+  sed -e 's/202[34]/YEARS/'
 }
 
 printf "=> Checking license headers\n"


### PR DESCRIPTION
## Motivation

This project has carved out space for example packages, showing how to adopt the package and integrate it with observability tooling for visualizing traces. The project has a great instructive example showing a fake work loop, emitting traces for each iteration. One common application for instrumentation is server applications so it would be good to have an example showing how to integrate this package into a HTTP server.

## Modifications

This PR adds another example package that shows a simple HTTP server application configured with instrumentation middleware. It uses the latest alpha release of Hummingbird, which supports Swift Service Lifecycle and provides a set of middlewares that instrument the server using the Swift Log, Swift Metrics, and Swift Tracing APIs. 

Along with the example itself is configuration for a Docker Compose application, which runs containers for collecting and visualizing the traces (OTel Collector and Jaeger, respectively).

The use of OTel Collector (cf. exporting directly to Jaeger, which now supports OTLP) is useful because it provides a single _receiver_ for collecting OTLP events, but can be configured with multiple _exporters_ and, optionally, _processors_. This example also shows the use of a `debug` exporter, which results in the traces being visible in the OTel Collector container logs. It also provides a simpler evolution for this example if it's expanded to include OTLP export for any of the other OTel signals, e.g. logs or metrics.

## Result

The project has another useful example that adopters can reference.

Closes #79

## Testing

**NOTE:** This PR does _not_ extend the CI config to build this new example project, which will be left to the repo maintainers. It does however build just fine:

```console
% swift run --package-path Examples/Server
Building for debugging...
Build complete! (0.22s)
2024-02-01T15:35:25+0000 trace OTelResourceDetection : detectors=["process", "environment", "manual"] [OTel] Running resource detectors.
2024-02-01T15:35:25+0000 trace OTelResourceDetection : detector=environment [OTel] Detected resource.
2024-02-01T15:35:25+0000 trace OTelResourceDetection : detector=manual [OTel] Detected resource.
2024-02-01T15:35:25+0000 trace OTelResourceDetection : detector=process [OTel] Detected resource.
2024-02-01T15:35:25+0000 debug OTelResourceDetection : service_name=example_server [OTel] Using service name from resource attributes.
2024-02-01T15:35:25+0000 debug OTLPGRPCSpanExporter : host=localhost port=4317 [OTLPGRPC] Using insecure connection.
2024-02-01T15:35:25+0000 info Hummingbird : [HummingbirdCore] Server started and listening on 127.0.0.1:8080
```

Additionally, the steps in the covering README that detail how to run the Compose application to collect and visualize the metrics have been tested locally.