### PR TITLE
Default group parameter of OTLPGRPCSpanExporter.init to MTELG.singleton

### DIFF
--- a/Examples/Counter/Sources/Example/Example.swift
+++ b/Examples/Counter/Sources/Example/Example.swift
@@ -43,11 +43,9 @@ enum Example {
         let logger = Logger(label: "example")
 
         /*
-         Here we create an event loop group and an OTel span exporter
-         that sends spans via gRPC to an OTel collector.
+         Here we create an OTel span exporter that sends spans via gRPC to an OTel collector.
          */
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let exporter = try OTLPGRPCSpanExporter(configuration: .init(environment: environment), group: group)
+        let exporter = try OTLPGRPCSpanExporter(configuration: .init(environment: environment))
 
         /*
          This exporter is passed to a batch span processor.

--- a/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
+++ b/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
@@ -37,7 +37,7 @@ public final class OTLPGRPCSpanExporter: OTelSpanExporter {
     ///   - backgroundActivityLogger: Logs info about the underlying gRPC connection. Defaults to disabled, i.e. not emitting any logs.
     public init(
         configuration: OTLPGRPCSpanExporterConfiguration,
-        group: any EventLoopGroup,
+        group: any EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         requestLogger: Logger = ._otelDisabled,
         backgroundActivityLogger: Logger = ._otelDisabled
     ) {


### PR DESCRIPTION
## Motivation

The `OTLPGRPCSpanExporter` initializer takes a `group: any  EventLoop` parameter. Since version 2.58.0, NIO has provided singletons for `EventLoopGroup`s, to make it easier for library adopters. This means we can continue to provide the ability for adopters to specify the ELG if they want/need to, but not require it if it's unimportant to the adopter.

## Modifications

Default group parameter of `OTLPGRPCSpanExporter.init` to `MTELG.singleton`.

## Result

It's no longer required to provide the `group:` parameter when initializing a `OTLPGRPCSpanExporter`.

## API change

Note that, while this is a change to a public API, it is backwards compatible.

[^1]: https://github.com/apple/swift-nio/releases/tag/2.58.0