### PR TITLE
[CI] Pass GitHub access token to Swiftly to avoid rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         uses: vapor/swiftly-action@v0.1
         with:
           toolchain: ${{ matrix.swift }}
+        env:
+          SWIFTLY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@v4.1.0
@@ -76,6 +78,8 @@ jobs:
         uses: vapor/swiftly-action@v0.1
         with:
           toolchain: latest
+        env:
+          SWIFTLY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v4.1.0
       - name: Resolve Swift dependencies


### PR DESCRIPTION
We've been hitting GitHub API rate limits[^1] via Swiftly. Passing an access token to Swiftly will increase these rate limits, thus making our CI more reliable.

[^1]: https://github.com/slashmo/swift-otel/actions/runs/7743762431/job/21116021359#step:2:144