### PR TITLE
Add metric store and registry types

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+                       The Swift OTel Project
+                       ======================
+
+Please visit the Swift OTel web site for more information:
+
+  * https://github.com/slashmo/swift-otel
+
+Copyright 2023 The Swift OTel Project
+
+The Swift OTel Project licenses this file to you under the Apache
+License, version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at:
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+Also, please refer to each LICENSE.txt file, which is located in
+the 'license' directory of the distribution file, for the license terms of the
+components that this product depends on.
+
+-------------------------------------------------------------------------------
+
+This product contains derivations of various scripts and templates from SwiftNIO.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/apple/swift-nio
+
+---
+
+This product contains metric backend types derived directly from swift-prometheus.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/swift-server/swift-prometheus
+
+---

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
 
         // MARK: - OTLP
 
@@ -38,6 +39,7 @@ let package = Package(
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
+                .product(name: "Atomics", package: "swift-atomics"),
             ],
             swiftSettings: sharedSwiftSettings
         ),

--- a/Sources/OTel/Helpers/HookedFatalError.swift
+++ b/Sources/OTel/Helpers/HookedFatalError.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct NIOConcurrencyHelpers.NIOLockedValueBox
+import XCTest
+
+func fatalError(_ message: @autoclosure () -> String = String(), file: StaticString = #file, line: UInt = #line) -> Never {
+    print("hooking fatal error")
+    hookedFatalError(message(), file: file, line: line)
+}
+
+package typealias FatalErrorHandler = @Sendable (String, _: StaticString, _: UInt) -> Void
+
+private let fatalErrorHandler: NIOLockedValueBox<FatalErrorHandler?> = .init(nil)
+
+private func hookedFatalError(_ message: String = "", file: StaticString = #file, line: UInt = #line) -> Never {
+    if let fatalErrorHandler = fatalErrorHandler.withLockedValue({ $0 }) {
+        print("\(#function): Running custom handler")
+        fatalErrorHandler(message, file, line)
+        print("\(#function): Parking thread")
+        while true { Thread.sleep(until: .distantFuture) }
+    } else {
+        Swift.fatalError(message, file: file, line: line)
+    }
+}
+
+package func withHookedFatalError<T>(
+    _ operation: () throws -> T,
+    onFatalError: @escaping FatalErrorHandler
+) rethrows -> T {
+    let previousFatalErrorHandler = fatalErrorHandler.withLockedValue {
+        let previousFatalErrorHandler = $0
+        $0 = onFatalError
+        return previousFatalErrorHandler
+    }
+    defer { fatalErrorHandler.withLockedValue { $0 = previousFatalErrorHandler } }
+    return try operation()
+}

--- a/Sources/OTel/Metrics/MetricStore/Attribute.swift
+++ b/Sources/OTel/Metrics/MetricStore/Attribute.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+struct Attribute: Equatable, Hashable, Sendable {
+    var key: String
+    var value: String
+}
+
+extension Set<Attribute> {
+    init(_ attributes: [(String, String)]) {
+        self.init(attributes.map { .init(key: $0.0, value: $0.1) })
+    }
+}

--- a/Sources/OTel/Metrics/MetricStore/Counter.swift
+++ b/Sources/OTel/Metrics/MetricStore/Counter.swift
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftPrometheus open source project
+//
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftPrometheus project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Atomics
+
+/// A counter is a cumulative metric that represents a single monotonically increasing
+/// counter whose value can only increase or be ``reset()`` to zero on restart.
+///
+/// For example, you can use a counter to represent the number of requests served, tasks completed, or errors.
+///
+/// Do not use a counter to expose a value that can decrease. For example, do not use a counter for the
+/// number of currently running processes; instead use a ``Gauge``.
+final class Counter: Sendable {
+    let intAtomic = ManagedAtomic(Int64(0))
+    let floatAtomic = ManagedAtomic(Double(0).bitPattern)
+
+    let name: String
+    let unit: String?
+    let description: String?
+    let attributes: Set<Attribute>
+
+    init(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = []) {
+        self.name = name
+        self.unit = unit
+        self.description = description
+        self.attributes = attributes
+    }
+
+    convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = []) {
+        self.init(name: name, unit: unit, description: description, attributes: Set(attributes))
+    }
+
+    func increment() {
+        increment(by: Int64(1))
+    }
+
+    func increment(by amount: Int64) {
+        precondition(amount >= 0)
+        intAtomic.wrappingIncrement(by: amount, ordering: .relaxed)
+    }
+
+    func increment(by amount: Double) {
+        precondition(amount >= 0)
+        // We busy loop here until we can update the atomic successfully.
+        // Using relaxed ordering here is sufficient, since the as-if rules guarantess that
+        // the following operations are executed in the order presented here. Every statement
+        // depends on the execution before.
+        while true {
+            let bits = floatAtomic.load(ordering: .relaxed)
+            let value = Double(bitPattern: bits) + amount
+            let (exchanged, _) = floatAtomic.compareExchange(
+                expected: bits,
+                desired: value.bitPattern,
+                ordering: .relaxed
+            )
+            if exchanged {
+                break
+            }
+        }
+    }
+
+    func reset() {
+        intAtomic.store(0, ordering: .relaxed)
+        floatAtomic.store(Double.zero.bitPattern, ordering: .relaxed)
+    }
+}

--- a/Sources/OTel/Metrics/MetricStore/Gauge.swift
+++ b/Sources/OTel/Metrics/MetricStore/Gauge.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftPrometheus open source project
+//
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftPrometheus project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Atomics
+
+/// A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
+///
+/// Gauges are typically used for measured values like temperatures or current memory usage, but
+/// also "counts" that can go up and down, like the number of concurrent requests.
+final class Gauge: Sendable {
+    let atomic = ManagedAtomic(Double.zero.bitPattern)
+
+    let name: String
+    let unit: String?
+    let description: String?
+    let attributes: Set<Attribute>
+
+    init(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = []) {
+        self.name = name
+        self.unit = unit
+        self.description = description
+        self.attributes = attributes
+    }
+
+    convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = []) {
+        self.init(name: name, unit: unit, description: description, attributes: Set(attributes))
+    }
+
+    func set(to value: Double) {
+        atomic.store(value.bitPattern, ordering: .relaxed)
+    }
+
+    func increment(by amount: Double = 1.0) {
+        // We busy loop here until we can update the atomic successfully.
+        // Using relaxed ordering here is sufficient, since the as-if rules guarantess that
+        // the following operations are executed in the order presented here. Every statement
+        // depends on the execution before.
+        while true {
+            let bits = atomic.load(ordering: .relaxed)
+            let value = Double(bitPattern: bits) + amount
+            let (exchanged, _) = atomic.compareExchange(
+                expected: bits,
+                desired: value.bitPattern,
+                ordering: .relaxed
+            )
+            if exchanged {
+                break
+            }
+        }
+    }
+
+    func decrement(by amount: Double = 1.0) {
+        increment(by: -amount)
+    }
+}

--- a/Sources/OTel/Metrics/MetricStore/Histogram.swift
+++ b/Sources/OTel/Metrics/MetricStore/Histogram.swift
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftPrometheus open source project
+//
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftPrometheus project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOConcurrencyHelpers
+
+/// A type that can be used in a ``Histogram`` to create bucket boundaries.
+protocol Bucketable: AdditiveArithmetic, Comparable, Sendable {
+    /// A bucket bound representation that is used in the OTLP export.
+    var bucketRepresentation: Double { get }
+}
+
+/// A Histogram to record timings.
+typealias DurationHistogram = Histogram<Duration>
+/// A Histogram to record floating point values.
+typealias ValueHistogram = Histogram<Double>
+
+/// A generic Histogram implementation
+final class Histogram<Value: Bucketable>: Sendable {
+    let name: String
+    let unit: String?
+    let description: String?
+    let attributes: Set<Attribute>
+
+    @usableFromInline
+    struct State: Sendable {
+        @usableFromInline var buckets: [(bound: Value, count: Int)]
+        @usableFromInline var sum: Value
+        @usableFromInline var count: Int
+
+        @inlinable
+        init(buckets: [Value]) {
+            sum = .zero
+            count = 0
+            self.buckets = buckets.map { ($0, 0) }
+        }
+    }
+
+    @usableFromInline let box: NIOLockedValueBox<State>
+
+    init(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = [], buckets: [Value]) {
+        self.name = name
+        self.unit = unit
+        self.description = description
+        self.attributes = attributes
+        box = .init(.init(buckets: buckets))
+    }
+
+    convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = [], buckets: [Value]) {
+        self.init(name: name, unit: unit, description: description, attributes: Set(attributes), buckets: buckets)
+    }
+
+    func record(_ value: Value) {
+        box.withLockedValue { state in
+            for i in state.buckets.startIndex ..< state.buckets.endIndex {
+                if state.buckets[i].0 >= value {
+                    state.buckets[i].1 += 1
+                }
+            }
+            state.sum += value
+            state.count += 1
+        }
+    }
+}
+
+extension Duration: Bucketable {
+    var bucketRepresentation: Double {
+        let attos = String(unsafeUninitializedCapacity: 18) { buffer in
+            var num = self.components.attoseconds
+
+            var positions = 17
+            var length: Int?
+            while positions >= 0 {
+                defer {
+                    positions -= 1
+                    num = num / 10
+                }
+                let remainder = num % 10
+
+                if length != nil {
+                    buffer[positions] = UInt8(ascii: "0") + UInt8(remainder)
+                } else {
+                    if remainder == 0 {
+                        continue
+                    }
+
+                    length = positions + 1
+                    buffer[positions] = UInt8(ascii: "0") + UInt8(remainder)
+                }
+            }
+
+            if length == nil {
+                buffer[0] = UInt8(ascii: "0")
+                length = 1
+            }
+
+            return length!
+        }
+        return Double("\(components.seconds).\(attos)")!
+    }
+}
+
+extension Double: Bucketable {
+    var bucketRepresentation: Double { self }
+}

--- a/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
+++ b/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
@@ -1,0 +1,300 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import struct NIOConcurrencyHelpers.NIOLockedValueBox
+
+/// A registry for metric instruments.
+///
+/// The registry owns the mapping from instrument identfier and attributes to the stateful instrument for recording
+/// measurements.
+public final class OTelMetricRegistry: Sendable {
+    private let logger = Logger(label: "OTelMetricRegistry")
+
+    struct Storage {
+        var counters = [InstrumentIdentifier: [Set<Attribute>: Counter]]()
+        var gauges = [InstrumentIdentifier: [Set<Attribute>: Gauge]]()
+        var valueHistograms = [InstrumentIdentifier: [Set<Attribute>: ValueHistogram]]()
+        var durationHistograms = [InstrumentIdentifier: [Set<Attribute>: DurationHistogram]]()
+
+        var registrations = [String: Set<InstrumentIdentifier>]()
+        let duplicateRegistrationHandler: DuplicateRegistrationHandler?
+
+        mutating func register(_ identifier: InstrumentIdentifier, forName name: String) {
+            if var existingRegistrations = registrations[name] {
+                duplicateRegistrationHandler?.handle(newRegistration: identifier, existingRegistrations: existingRegistrations)
+                existingRegistrations.insert(identifier)
+                registrations[name] = existingRegistrations
+            } else {
+                registrations[name] = [identifier]
+            }
+        }
+
+        mutating func unregister(_ identifier: InstrumentIdentifier, forName name: String) {
+            guard var existingRegistrations = registrations[name] else { return }
+            existingRegistrations.remove(identifier)
+            if existingRegistrations.isEmpty {
+                registrations.removeValue(forKey: name)
+            }
+        }
+    }
+
+    let storage: NIOLockedValueBox<Storage>
+
+    /// A duplicate instrument registration occurs when more than one instrument of the same
+    /// name is created with different _identifying fields_.
+    public struct DuplicateRegistrationBehavior: Sendable {
+        enum Behavior: Sendable {
+            case warn, crash
+        }
+
+        var behavior: Behavior
+
+        /// Emits a log message at warning level.
+        public static let warn = Self(behavior: .warn)
+
+        /// Crashes with a fatal error.
+        public static let crash = Self(behavior: .crash)
+    }
+
+    internal init(duplicateRegistrationHandler: some DuplicateRegistrationHandler) {
+        self.storage = .init(Storage(duplicateRegistrationHandler: duplicateRegistrationHandler))
+    }
+
+    /// Create a new ``OTelMetricRegistry``.
+    /// - Parameters:
+    ///   - onDuplicateRegistration: Action to take when more than one instrument of the same name is created with
+    ///     different identifying fields.
+    ///
+    /// - Seealso: ``OTelMetricRegistry/DuplicateRegistrationBehavior``.
+    public convenience init(onDuplicateRegistration: DuplicateRegistrationBehavior = .warn) {
+        switch onDuplicateRegistration.behavior {
+        case .warn:
+            self.init(duplicateRegistrationHandler: WarningDuplicateRegistrationHandler.default)
+        case .crash:
+            self.init(duplicateRegistrationHandler: FatalErrorDuplicateRegistrationHandler())
+        }
+    }
+
+    func makeCounter(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = []) -> Counter {
+        storage.withLockedValue { storage in
+            let identifier = InstrumentIdentifier.counter(name: name, unit: unit, description: description)
+            if var existingInstruments = storage.counters[identifier] {
+                if let existingInstrument = existingInstruments[attributes] {
+                    return existingInstrument
+                }
+                let newInstrument = Counter(name: name, unit: unit, description: description, attributes: attributes)
+                existingInstruments[attributes] = newInstrument
+                return newInstrument
+            }
+            storage.register(identifier, forName: name)
+            let newInstrument = Counter(name: name, unit: unit, description: description, attributes: attributes)
+            storage.counters[identifier] = [attributes: newInstrument]
+            return newInstrument
+        }
+    }
+
+    func makeGauge(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = []) -> Gauge {
+        storage.withLockedValue { storage in
+            let identifier = InstrumentIdentifier.gauge(name: name, unit: unit, description: description)
+            if var existingInstruments = storage.gauges[identifier] {
+                if let existingInstrument = existingInstruments[attributes] {
+                    return existingInstrument
+                }
+                let newInstrument = Gauge(name: name, unit: unit, description: description, attributes: attributes)
+                existingInstruments[attributes] = newInstrument
+                return newInstrument
+            }
+            storage.register(identifier, forName: name)
+            let newInstrument = Gauge(name: name, unit: unit, description: description, attributes: attributes)
+            storage.gauges[identifier] = [attributes: newInstrument]
+            return newInstrument
+        }
+    }
+
+    func makeDurationHistogram(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = [], buckets: [Duration]) -> DurationHistogram {
+        storage.withLockedValue { storage in
+            let identifier = InstrumentIdentifier.histogram(name: name, unit: unit, description: description)
+            if var existingInstruments = storage.durationHistograms[identifier] {
+                if let existingInstrument = existingInstruments[attributes] {
+                    return existingInstrument
+                }
+                let newInstrument = DurationHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
+                existingInstruments[attributes] = newInstrument
+                return newInstrument
+            }
+            storage.register(identifier, forName: name)
+            let newInstrument = DurationHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
+            storage.durationHistograms[identifier] = [attributes: newInstrument]
+            return newInstrument
+        }
+    }
+
+    func makeValueHistogram(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = [], buckets: [Double]) -> ValueHistogram {
+        storage.withLockedValue { storage in
+            let identifier = InstrumentIdentifier.histogram(name: name, unit: unit, description: description)
+            if var existingInstruments = storage.valueHistograms[identifier] {
+                if let existingInstrument = existingInstruments[attributes] {
+                    return existingInstrument
+                }
+                let newInstrument = ValueHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
+                existingInstruments[attributes] = newInstrument
+                return newInstrument
+            }
+            storage.register(identifier, forName: name)
+            let newInstrument = ValueHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
+            storage.valueHistograms[identifier] = [attributes: newInstrument]
+            return newInstrument
+        }
+    }
+
+    func unregisterCounter(_ counter: Counter) {
+        let identifier = counter.instrumentIdentifier
+        self.storage.withLockedValue { storage in
+            if var existingInstrument = storage.counters[identifier] {
+                existingInstrument.removeValue(forKey: counter.attributes)
+                if existingInstrument.isEmpty {
+                    storage.counters.removeValue(forKey: identifier)
+                    storage.unregister(identifier, forName: identifier.name)
+                }
+            }
+        }
+    }
+
+    func unregisterGauge(_ gauge: Gauge) {
+        let identifier = gauge.instrumentIdentifier
+        self.storage.withLockedValue { storage in
+            if var existingInstrument = storage.gauges[identifier] {
+                existingInstrument.removeValue(forKey: gauge.attributes)
+                if existingInstrument.isEmpty {
+                    storage.gauges.removeValue(forKey: identifier)
+                    storage.unregister(identifier, forName: identifier.name)
+                }
+            }
+        }
+    }
+
+    func unregisterDurationHistogram(_ histogram: DurationHistogram) {
+        let identifier = histogram.instrumentIdentifier
+        self.storage.withLockedValue { storage in
+            if var existingInstrument = storage.durationHistograms[identifier] {
+                existingInstrument.removeValue(forKey: histogram.attributes)
+                if existingInstrument.isEmpty {
+                    storage.durationHistograms.removeValue(forKey: identifier)
+                    storage.unregister(identifier, forName: identifier.name)
+                }
+            }
+        }
+    }
+
+    func unregisterValueHistogram(_ histogram: ValueHistogram) {
+        let identifier = histogram.instrumentIdentifier
+        self.storage.withLockedValue { storage in
+            if var existingInstrument = storage.valueHistograms[identifier] {
+                existingInstrument.removeValue(forKey: histogram.attributes)
+                if existingInstrument.isEmpty {
+                    storage.valueHistograms.removeValue(forKey: identifier)
+                    storage.unregister(identifier, forName: identifier.name)
+                }
+            }
+        }
+    }
+}
+
+extension OTelMetricRegistry {
+    func makeCounter(name: String, unit: String? = nil, description: String? = nil, labels: [(String, String)]) -> Counter {
+        makeCounter(name: name, unit: unit, description: description, attributes: Set(labels))
+    }
+
+    func makeGauge(name: String, unit: String? = nil, description: String? = nil, labels: [(String, String)]) -> Gauge {
+        makeGauge(name: name, unit: unit, description: description, attributes: Set(labels))
+    }
+
+    func makeDurationHistogram(name: String, unit: String? = nil, description: String? = nil, labels: [(String, String)], buckets: [Duration]) -> DurationHistogram {
+        makeDurationHistogram(name: name, unit: unit, description: description, attributes: Set(labels), buckets: buckets)
+    }
+
+    func makeValueHistogram(name: String, unit: String? = nil, description: String? = nil, labels: [(String, String)], buckets: [Double]) -> ValueHistogram {
+        makeValueHistogram(name: name, unit: unit, description: description, attributes: Set(labels), buckets: buckets)
+    }
+}
+
+struct InstrumentIdentifier: Equatable, Hashable, Sendable {
+    var name: String
+    var unit: String?
+    var description: String?
+    enum InstrumentKind { case counter, gauge, histogram }
+    var kind: InstrumentKind
+
+    private init(name: String, unit: String? = nil, description: String? = nil, kind: InstrumentKind) {
+        self.name = name.lowercased()
+        self.unit = unit
+        self.description = description
+        self.kind = kind
+    }
+
+    static func counter(name: String, unit: String? = nil, description: String? = nil) -> Self {
+        self.init(name: name, unit: unit, description: description, kind: .counter)
+    }
+
+    static func gauge(name: String, unit: String? = nil, description: String? = nil) -> Self {
+        self.init(name: name, unit: unit, description: description, kind: .gauge)
+    }
+
+    static func histogram(name: String, unit: String? = nil, description: String? = nil) -> Self {
+        self.init(name: name, unit: unit, description: description, kind: .histogram)
+    }
+}
+
+protocol IdentifiableInstrument {
+    var instrumentIdentifier: InstrumentIdentifier { get }
+}
+
+extension Counter: IdentifiableInstrument {
+    var instrumentIdentifier: InstrumentIdentifier { .counter(name: name, unit: unit, description: description) }
+}
+
+extension Gauge: IdentifiableInstrument {
+    var instrumentIdentifier: InstrumentIdentifier { .gauge(name: name, unit: unit, description: description) }
+}
+
+extension Histogram: IdentifiableInstrument {
+    var instrumentIdentifier: InstrumentIdentifier { .histogram(name: name, unit: unit, description: description) }
+}
+
+protocol DuplicateRegistrationHandler: Sendable {
+    func handle(newRegistration: InstrumentIdentifier, existingRegistrations: Set<InstrumentIdentifier>)
+}
+
+struct FatalErrorDuplicateRegistrationHandler: DuplicateRegistrationHandler {
+    func handle(newRegistration: InstrumentIdentifier, existingRegistrations: Set<InstrumentIdentifier>) {
+        fatalError("""
+        Duplicate instrument registration for name: \(newRegistration.name)
+        ---
+        Instrument \(newRegistration) conflicts with existing instruments: \(existingRegistrations).
+        """)
+    }
+}
+
+struct WarningDuplicateRegistrationHandler: DuplicateRegistrationHandler {
+    let logger: Logger
+
+    func handle(newRegistration: InstrumentIdentifier, existingRegistrations: Set<InstrumentIdentifier>) {
+        self.logger.warning("Duplicate instrument registration", metadata: [
+            "newRegistration": "\(newRegistration)",
+            "existingRegistrations": .array(existingRegistrations.map { "\($0)" }),
+        ])
+    }
+
+    static let `default` = Self(logger: Logger(label: "OTelMetricRegistry"))
+}

--- a/Sources/OTelTesting/RecordingDuplicateRegistrationHandler.swift
+++ b/Sources/OTelTesting/RecordingDuplicateRegistrationHandler.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOConcurrencyHelpers
+@testable import OTel
+
+package final class RecordingDuplicateRegistrationHandler: DuplicateRegistrationHandler {
+    package let invocations = NIOLockedValueBox([(InstrumentIdentifier, Set<InstrumentIdentifier>)]())
+
+    package init() {}
+
+    package func handle(newRegistration: InstrumentIdentifier, existingRegistrations: Set<InstrumentIdentifier>) {
+        invocations.withLockedValue { $0.append((newRegistration, existingRegistrations)) }
+    }
+}

--- a/Sources/OTelTesting/RecordingLogHandler.swift
+++ b/Sources/OTelTesting/RecordingLogHandler.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOConcurrencyHelpers
+
+package struct RecordingLogHandler: LogHandler {
+    package typealias LogFunctionCall = (level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?)
+
+    package let recordedLogMessages = NIOLockedValueBox([LogFunctionCall]())
+
+    package init() {}
+
+    package func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
+        recordedLogMessages.withLockedValue { $0.append((level, message, metadata)) }
+    }
+
+    package var metadata: Logging.Logger.Metadata {
+        get { [:] }
+        set(newValue) { fatalError("unimplemented") }
+    }
+
+    package var logLevel: Logging.Logger.Level {
+        get { .trace }
+        set(newValue) { fatalError("unimplemented") }
+    }
+
+    package subscript(metadataKey _: String) -> Logging.Logger.Metadata.Value? {
+        get { fatalError("unimplemented") }
+        set(newValue) { fatalError("unimplemented") }
+    }
+}

--- a/Sources/OTelTesting/XCTAssertThrowsFatalError.swift
+++ b/Sources/OTelTesting/XCTAssertThrowsFatalError.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import OTel
+import XCTest
+
+package func XCTAssertThrowsFatalError(
+    _ expectedMessage: @escaping @Sendable @autoclosure () -> String? = nil,
+    timeout seconds: TimeInterval = 0.1,
+    _ expression: @escaping @Sendable () -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    let hookedFatalErrorCalled = XCTestExpectation(description: "hooked fatalError called")
+    withHookedFatalError {
+        DispatchQueue.global().async { expression() }
+        guard case .completed = XCTWaiter.wait(for: [hookedFatalErrorCalled], timeout: seconds) else {
+            XCTFail("Operation did not throw fatalError", file: file, line: line)
+            return
+        }
+    } onFatalError: { message, _, _ in
+        hookedFatalErrorCalled.fulfill()
+        if let expectedMessage = expectedMessage() {
+            XCTAssertEqual(message, expectedMessage, "Operation threw fatalError but with unexpected message", file: file, line: line)
+        }
+    }
+}

--- a/Tests/OTelTests/Helpers/HookedFatalErrorTests.swift
+++ b/Tests/OTelTests/Helpers/HookedFatalErrorTests.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+@testable import OTelTesting
+import XCTest
+
+final class HookedFatalErrorTests: XCTestCase {
+    func testHookedFatalError_functionFatalErrors_runsHandler() async {
+        let functionReturned = expectation(description: "function returned")
+        functionReturned.isInverted = true
+        let fatalErrorHandlerRun = expectation(description: "handler run")
+        DispatchQueue.global().async {
+            withHookedFatalError {
+                if true { fatalError("boom") }
+            } onFatalError: { message, _, _ in
+                XCTAssertEqual(message, "boom")
+                fatalErrorHandlerRun.fulfill()
+            }
+            functionReturned.fulfill()
+        }
+        await fulfillment(of: [functionReturned, fatalErrorHandlerRun], timeout: 0.1)
+    }
+
+    func testHookedFatalError_functionDoesNotFatalError_doesNotrunHandler() async {
+        let functionReturned = expectation(description: "function returned")
+        let fatalErrorHandlerRun = expectation(description: "handler run")
+        fatalErrorHandlerRun.isInverted = true
+        DispatchQueue.global().async {
+            withHookedFatalError {} onFatalError: { _, _, _ in
+                fatalErrorHandlerRun.fulfill()
+            }
+            functionReturned.fulfill()
+        }
+        await fulfillment(of: [functionReturned, fatalErrorHandlerRun], timeout: 0.1)
+    }
+
+    func testXCTAssertThrowsFatalError() async {
+        XCTAssertThrowsFatalError {
+            fatalError()
+        }
+        XCTAssertThrowsFatalError("foo") {
+            fatalError("foo")
+        }
+    }
+}

--- a/Tests/OTelTests/Metrics/MetricStore/CounterTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/CounterTests.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import XCTest
+
+final class CounterTests: XCTestCase {
+    func test_increment() {
+        let counter = Counter(name: "my_counter", attributes: [])
+        counter.assertStateEquals(integerPart: 0, doublePart: 0)
+
+        counter.increment(by: Int64(0))
+        counter.assertStateEquals(integerPart: 0, doublePart: 0)
+
+        counter.increment()
+        counter.assertStateEquals(integerPart: 1, doublePart: 0)
+
+        counter.increment(by: Int64(1))
+        counter.assertStateEquals(integerPart: 2, doublePart: 0)
+
+        counter.increment(by: Double(1.5))
+        counter.assertStateEquals(integerPart: 2, doublePart: 1.5)
+
+        counter.increment(by: Int64(2))
+        counter.assertStateEquals(integerPart: 4, doublePart: 1.5)
+
+        counter.reset()
+        counter.assertStateEquals(integerPart: 0, doublePart: 0)
+    }
+
+    func test_increment_concurrent() async {
+        let counter = Counter(name: "my_counter", attributes: [])
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 100_000 {
+                group.addTask {
+                    counter.increment(by: Double(1))
+                }
+            }
+            for _ in 0 ..< 100_000 {
+                group.addTask {
+                    counter.increment(by: Int64(1))
+                }
+            }
+        }
+        counter.assertStateEquals(integerPart: 100_000, doublePart: 100_000)
+    }
+}
+
+extension Counter {
+    private var integerAtomicValue: Int64 { intAtomic.load(ordering: .relaxed) }
+    private var doubleAtomicValue: Double { Double(bitPattern: floatAtomic.load(ordering: .relaxed)) }
+
+    fileprivate func assertStateEquals(integerPart: Int64, doublePart: Double, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(integerAtomicValue, integerPart, "Unexpected integer part", file: file, line: line)
+        XCTAssertEqual(doubleAtomicValue, doublePart, "Unexpected double part", file: file, line: line)
+    }
+}

--- a/Tests/OTelTests/Metrics/MetricStore/GaugeTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/GaugeTests.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import XCTest
+
+final class GaugeTests: XCTestCase {
+    func test_incrementDecrement() {
+        let gauge = Gauge(name: "my_gauge", attributes: [])
+        XCTAssertEqual(gauge.doubleAtomicValue, 0.0)
+
+        gauge.decrement(by: 0)
+        XCTAssertEqual(gauge.doubleAtomicValue, 0.0)
+
+        gauge.increment(by: 0)
+        XCTAssertEqual(gauge.doubleAtomicValue, 0.0)
+
+        gauge.decrement()
+        XCTAssertEqual(gauge.doubleAtomicValue, -1.0)
+
+        gauge.decrement(by: 2)
+        XCTAssertEqual(gauge.doubleAtomicValue, -3.0)
+
+        gauge.increment()
+        XCTAssertEqual(gauge.doubleAtomicValue, -2.0)
+
+        gauge.increment(by: 2.5)
+        XCTAssertEqual(gauge.doubleAtomicValue, 0.5)
+
+        gauge.set(to: 42)
+        XCTAssertEqual(gauge.doubleAtomicValue, 42.0)
+
+        gauge.set(to: 42.99)
+        XCTAssertEqual(gauge.doubleAtomicValue, 42.99)
+    }
+
+    func test_incrementDecrement_concurrent() async {
+        let gauge = Gauge(name: "my_gauge", attributes: [])
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 100_000 {
+                group.addTask {
+                    gauge.increment(by: 3.5)
+                }
+            }
+            for _ in 0 ..< 100_000 {
+                group.addTask {
+                    gauge.decrement(by: 2.5)
+                }
+            }
+        }
+        XCTAssertEqual(gauge.doubleAtomicValue, 100_000.0)
+    }
+}
+
+extension Gauge {
+    fileprivate var doubleAtomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
+}

--- a/Tests/OTelTests/Metrics/MetricStore/HistogramTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/HistogramTests.swift
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import XCTest
+
+final class HistogramTests: XCTestCase {
+    func test_record() {
+        let histogram = DurationHistogram(name: "my_histogram", attributes: [], buckets: [
+            .milliseconds(100),
+            .milliseconds(250),
+            .milliseconds(500),
+            .seconds(1),
+        ])
+        histogram.box.withLockedValue { _ in
+        }
+        histogram.assertStateEquals(count: 0, sum: .zero, buckets: [
+            (bound: .milliseconds(100), count: 0),
+            (bound: .milliseconds(250), count: 0),
+            (bound: .milliseconds(500), count: 0),
+            (bound: .seconds(1), count: 0),
+        ])
+
+        histogram.record(.milliseconds(400))
+        histogram.assertStateEquals(count: 1, sum: .milliseconds(400), buckets: [
+            (bound: .milliseconds(100), count: 0),
+            (bound: .milliseconds(250), count: 0),
+            (bound: .milliseconds(500), count: 1),
+            (bound: .seconds(1), count: 1),
+        ])
+
+        histogram.record(.milliseconds(600))
+        histogram.assertStateEquals(count: 2, sum: .milliseconds(1000), buckets: [
+            (bound: .milliseconds(100), count: 0),
+            (bound: .milliseconds(250), count: 0),
+            (bound: .milliseconds(500), count: 1),
+            (bound: .seconds(1), count: 2),
+        ])
+
+        histogram.record(.milliseconds(1200))
+        histogram.assertStateEquals(count: 3, sum: .milliseconds(2200), buckets: [
+            (bound: .milliseconds(100), count: 0),
+            (bound: .milliseconds(250), count: 0),
+            (bound: .milliseconds(500), count: 1),
+            (bound: .seconds(1), count: 2),
+        ])
+
+        histogram.record(.milliseconds(80))
+        histogram.assertStateEquals(count: 4, sum: .milliseconds(2280), buckets: [
+            (bound: .milliseconds(100), count: 1),
+            (bound: .milliseconds(250), count: 1),
+            (bound: .milliseconds(500), count: 2),
+            (bound: .seconds(1), count: 3),
+        ])
+    }
+
+    func test_record_concurrent() async {
+        let histogram = DurationHistogram(name: "my_histogram", attributes: [], buckets: [
+            .milliseconds(500),
+            .milliseconds(700),
+        ])
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 100_000 {
+                group.addTask {
+                    histogram.record(.milliseconds(400))
+                }
+            }
+            for _ in 0 ..< 100_000 {
+                group.addTask {
+                    histogram.record(.milliseconds(600))
+                }
+            }
+        }
+        histogram.assertStateEquals(count: 200_000, sum: .seconds(100_000), buckets: [
+            (bound: .milliseconds(500), count: 100_000),
+            (bound: .milliseconds(700), count: 200_000),
+        ])
+    }
+
+    func test_bucketRepresentation_duration() {
+        for (duration, expectedBucketRepresentation) in [
+            .zero: 0.0,
+            .seconds(1): 1.0,
+            .milliseconds(500): 0.5,
+            .milliseconds(250): 0.25,
+            .nanoseconds(1): 1e-9,
+            Duration(secondsComponent: 0, attosecondsComponent: 1): 1e-18,
+            .seconds(2) + Duration(secondsComponent: 0, attosecondsComponent: 1): 2 + 1e-18,
+        ] {
+            XCTAssertEqual(duration.bucketRepresentation, expectedBucketRepresentation)
+        }
+    }
+
+    func test_bucketRepresentation_double() {
+        for value in [
+            .zero,
+            .greatestFiniteMagnitude,
+            .infinity,
+            .leastNonzeroMagnitude,
+            .leastNormalMagnitude,
+            .pi,
+            .ulpOfOne,
+            1.2,
+            -2.1,
+        ] {
+            XCTAssertEqual(value.bucketRepresentation, value)
+        }
+        XCTAssert(Double.nan.bucketRepresentation.isNaN)
+        XCTAssert(Double.signalingNaN.bucketRepresentation.isSignalingNaN)
+    }
+}
+
+extension DurationHistogram {
+    fileprivate struct EquatableBucket: Equatable {
+        var bound: Duration
+        var count: Int
+    }
+
+    fileprivate func assertStateEquals(
+        count: Int,
+        sum: Duration,
+        buckets: [(bound: Duration, count: Int)],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let state = box.withLockedValue { $0 }
+        XCTAssertEqual(state.count, count, "Unexpected count", file: file, line: line)
+        XCTAssertEqual(state.sum, sum, "Unexpected sum", file: file, line: line)
+        XCTAssertEqual(
+            state.buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
+            buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
+            "Unexpected buckets",
+            file: file, line: line
+        )
+    }
+}

--- a/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
@@ -1,0 +1,318 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import struct NIOConcurrencyHelpers.NIOLockedValueBox
+@testable import OTel
+import OTelTesting
+import XCTest
+
+final class OTelMetricRegistryTests: XCTestCase {
+    func test_identity_SameName_Identical() {
+        let registry = OTelMetricRegistry()
+        XCTAssertIdentical(
+            registry.makeCounter(name: "c"),
+            registry.makeCounter(name: "c")
+        )
+        XCTAssertIdentical(
+            registry.makeGauge(name: "g"),
+            registry.makeGauge(name: "g")
+        )
+        XCTAssertIdentical(
+            registry.makeDurationHistogram(name: "d", buckets: []),
+            registry.makeDurationHistogram(name: "d", buckets: [])
+        )
+        XCTAssertIdentical(
+            registry.makeValueHistogram(name: "v", buckets: []),
+            registry.makeValueHistogram(name: "v", buckets: [])
+        )
+    }
+
+    func test_identity_sameNameDifferentCase_identical() throws {
+        let registry = OTelMetricRegistry()
+
+        XCTAssertIdentical(
+            registry.makeCounter(name: "c"),
+            registry.makeCounter(name: "C")
+        )
+        XCTAssertIdentical(
+            registry.makeGauge(name: "G"),
+            registry.makeGauge(name: "g")
+        )
+        XCTAssertIdentical(
+            registry.makeDurationHistogram(name: "duration_histogram", buckets: []),
+            registry.makeDurationHistogram(name: "dUrAtIoN_hIsToGrAm", buckets: [])
+        )
+        XCTAssertIdentical(
+            registry.makeValueHistogram(name: "value_histogram", buckets: []),
+            registry.makeValueHistogram(name: "vAlUe_hIsToGrAm", buckets: [])
+        )
+    }
+
+    func test_identity_sameNameSameLabels_identical() {
+        let registry = OTelMetricRegistry()
+        XCTAssertIdentical(
+            registry.makeCounter(name: "c", labels: [("one", "1")]),
+            registry.makeCounter(name: "c", labels: [("one", "1")])
+        )
+        XCTAssertIdentical(
+            registry.makeGauge(name: "g", labels: [("one", "1")]),
+            registry.makeGauge(name: "g", labels: [("one", "1")])
+        )
+        XCTAssertIdentical(
+            registry.makeDurationHistogram(name: "d", labels: [("one", "1")], buckets: []),
+            registry.makeDurationHistogram(name: "d", labels: [("one", "1")], buckets: [])
+        )
+        XCTAssertIdentical(
+            registry.makeValueHistogram(name: "v", labels: [("one", "1")], buckets: []),
+            registry.makeValueHistogram(name: "v", labels: [("one", "1")], buckets: [])
+        )
+    }
+
+    func test_identity_sameNameDifferentOrder_identical() {
+        let registry = OTelMetricRegistry()
+        XCTAssertIdentical(
+            registry.makeCounter(name: "c", labels: [("one", "1"), ("two", "2")]),
+            registry.makeCounter(name: "c", labels: [("two", "2"), ("one", "1")])
+        )
+        XCTAssertIdentical(
+            registry.makeGauge(name: "g", labels: [("one", "1"), ("two", "2")]),
+            registry.makeGauge(name: "g", labels: [("two", "2"), ("one", "1")])
+        )
+        XCTAssertIdentical(
+            registry.makeDurationHistogram(name: "d", labels: [("one", "1"), ("two", "2")], buckets: []),
+            registry.makeDurationHistogram(name: "d", labels: [("two", "2"), ("one", "1")], buckets: [])
+        )
+        XCTAssertIdentical(
+            registry.makeValueHistogram(name: "v", labels: [("one", "1"), ("two", "2")], buckets: []),
+            registry.makeValueHistogram(name: "v", labels: [("two", "2"), ("one", "1")], buckets: [])
+        )
+    }
+
+    func test_identity_differentNamesNoLabels_distinct() {
+        let registry = OTelMetricRegistry()
+        XCTAssertNotIdentical(
+            registry.makeCounter(name: "c1"),
+            registry.makeCounter(name: "c2")
+        )
+        XCTAssertNotIdentical(
+            registry.makeGauge(name: "g1"),
+            registry.makeGauge(name: "g2")
+        )
+        XCTAssertNotIdentical(
+            registry.makeDurationHistogram(name: "h1", buckets: []),
+            registry.makeDurationHistogram(name: "h2", buckets: [])
+        )
+        XCTAssertNotIdentical(
+            registry.makeValueHistogram(name: "v1", buckets: []),
+            registry.makeValueHistogram(name: "v2", buckets: [])
+        )
+    }
+
+    func test_identity_sameNameSameLabelKeysDifferentValues_distinct() {
+        let registry = OTelMetricRegistry()
+        XCTAssertNotIdentical(
+            registry.makeCounter(name: "c", labels: [("x", "1"), ("y", "2")]),
+            registry.makeCounter(name: "c", labels: [("x", "2"), ("y", "4")])
+        )
+        XCTAssertNotIdentical(
+            registry.makeGauge(name: "g", labels: [("x", "1"), ("y", "2")]),
+            registry.makeGauge(name: "g", labels: [("x", "2"), ("y", "4")])
+        )
+        XCTAssertNotIdentical(
+            registry.makeDurationHistogram(name: "d", labels: [("x", "1"), ("y", "2")], buckets: []),
+            registry.makeDurationHistogram(name: "d", labels: [("x", "2"), ("y", "4")], buckets: [])
+        )
+        XCTAssertNotIdentical(
+            registry.makeValueHistogram(name: "v", labels: [("x", "1"), ("y", "2")], buckets: []),
+            registry.makeValueHistogram(name: "v", labels: [("x", "2"), ("y", "4")], buckets: [])
+        )
+    }
+
+    func test_identity_sameNameDifferentLabelKeys_distinct() throws {
+        let registry = OTelMetricRegistry()
+
+        XCTAssertNotIdentical(
+            registry.makeCounter(name: "c", labels: [("x", "1")]),
+            registry.makeCounter(name: "c", labels: [("y", "1")])
+        )
+        XCTAssertNotIdentical(
+            registry.makeGauge(name: "g", labels: [("x", "1")]),
+            registry.makeGauge(name: "g", labels: [("y", "1")])
+        )
+        XCTAssertNotIdentical(
+            registry.makeDurationHistogram(name: "d", labels: [("x", "1")], buckets: []),
+            registry.makeDurationHistogram(name: "d", labels: [("y", "1")], buckets: [])
+        )
+        XCTAssertNotIdentical(
+            registry.makeValueHistogram(name: "v", labels: [("x", "1")], buckets: []),
+            registry.makeValueHistogram(name: "v", labels: [("y", "1")], buckets: [])
+        )
+    }
+
+    func test_identity_sameNameAdditionalLabels_distinct() throws {
+        let registry = OTelMetricRegistry()
+
+        XCTAssertNotIdentical(
+            registry.makeCounter(name: "c", labels: [("x", "1")]),
+            registry.makeCounter(name: "c", labels: [("x", "1"), ("y", "1")])
+        )
+
+        XCTAssertNotIdentical(
+            registry.makeGauge(name: "g", labels: [("x", "1")]),
+            registry.makeGauge(name: "g", labels: [("x", "1"), ("y", "1")])
+        )
+
+        XCTAssertNotIdentical(
+            registry.makeDurationHistogram(name: "d", labels: [("x", "1")], buckets: []),
+            registry.makeDurationHistogram(name: "d", labels: [("x", "1"), ("y", "1")], buckets: [])
+        )
+        XCTAssertNotIdentical(
+            registry.makeValueHistogram(name: "v", labels: [("x", "1")], buckets: []),
+            registry.makeValueHistogram(name: "v", labels: [("x", "1"), ("y", "1")], buckets: [])
+        )
+    }
+
+    func test_identity_sameNameSameLabelsDifferentBuckets_identical() throws {
+        let registry = OTelMetricRegistry()
+
+        XCTAssertIdentical(
+            registry.makeDurationHistogram(name: "d", labels: [("x", "1")], buckets: [.seconds(1)]),
+            registry.makeDurationHistogram(name: "d", labels: [("x", "1")], buckets: [.seconds(2)])
+        )
+        XCTAssertIdentical(
+            registry.makeValueHistogram(name: "v", labels: [("x", "1")], buckets: [1]),
+            registry.makeValueHistogram(name: "v", labels: [("x", "1")], buckets: [2])
+        )
+    }
+
+    func test_identity_sameNameDifferentIdentity_distinctAndCallsHandler() throws {
+        let handler = RecordingDuplicateRegistrationHandler()
+        let registry = OTelMetricRegistry(duplicateRegistrationHandler: handler)
+
+        // Start with no invocations.
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 0)
+
+        // Registering a new metric does not invoke handler.
+        _ = registry.makeCounter(name: "name", labels: [("x", "1")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 0)
+
+        // Registering the same metric does not invoke handler.
+        _ = registry.makeCounter(name: "name", labels: [("x", "1")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 0)
+
+        // Registering a metric with the same identifying fields but different attributes does not invoke handler.
+        _ = registry.makeCounter(name: "name", labels: [("y", "2")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 0)
+
+        // Registring a metric of the same type but with a different identifying field invokes the handler once only.
+        _ = registry.makeCounter(name: "name", unit: "new_unit", labels: [("x", "1")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 1)
+        _ = registry.makeCounter(name: "name", unit: "new_unit", labels: [("x", "1")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 1)
+
+        // OTel spec also states that description is also an identifying field.
+        _ = registry.makeCounter(name: "name", unit: "new_unit", description: "new description", labels: [("x", "1")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 2)
+        _ = registry.makeCounter(name: "name", unit: "new_unit", description: "new description", labels: [("x", "1")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 2)
+
+        // The kind of instrument is, of course, also an identifying field.
+        _ = registry.makeGauge(name: "name", labels: [("x", "1")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 3)
+        _ = registry.makeGauge(name: "name", labels: [("x", "1")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 3)
+
+        // Same for histogram...
+        _ = registry.makeValueHistogram(name: "name", labels: [("x", "1")], buckets: [1])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 4)
+        _ = registry.makeValueHistogram(name: "name", labels: [("x", "1")], buckets: [1])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 4)
+
+        // ...but currently we do _not_ consider the buckets to be identifying.
+        _ = registry.makeValueHistogram(name: "name", labels: [("x", "1")], buckets: [2])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 4)
+
+        // While name is an identifying field, it is treated case-insensitively.
+        _ = registry.makeCounter(name: "NaMe", labels: [("x", "1")])
+        XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 4)
+    }
+
+    func test_unregisterReregister_withoutLabels() {
+        let duplicateRegistrationHandler = RecordingDuplicateRegistrationHandler()
+        let registry = OTelMetricRegistry(duplicateRegistrationHandler: duplicateRegistrationHandler)
+
+        registry.unregisterCounter(registry.makeCounter(name: "name"))
+        registry.unregisterGauge(registry.makeGauge(name: "name"))
+        registry.unregisterDurationHistogram(registry.makeDurationHistogram(name: "name", buckets: []))
+        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", buckets: []))
+        _ = registry.makeCounter(name: "name")
+
+        XCTAssertEqual(duplicateRegistrationHandler.invocations.withLockedValue { $0 }.count, 0)
+    }
+
+    func test_unregisterReregister_withLabels() {
+        let duplicateRegistrationHandler = RecordingDuplicateRegistrationHandler()
+        let registry = OTelMetricRegistry(duplicateRegistrationHandler: duplicateRegistrationHandler)
+
+        registry.unregisterCounter(registry.makeCounter(name: "name", labels: [("a", "1")]))
+        registry.unregisterCounter(registry.makeCounter(name: "name", labels: [("b", "1")]))
+
+        registry.unregisterGauge(registry.makeGauge(name: "name", labels: [("a", "1")]))
+        registry.unregisterGauge(registry.makeGauge(name: "name", labels: [("b", "1")]))
+
+        registry.unregisterDurationHistogram(registry.makeDurationHistogram(name: "name", labels: [("a", "1")], buckets: []))
+        registry.unregisterDurationHistogram(registry.makeDurationHistogram(name: "name", labels: [("b", "1")], buckets: []))
+
+        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", labels: [("a", "1")], buckets: []))
+        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", labels: [("b", "1")], buckets: []))
+
+        _ = registry.makeCounter(name: "name", labels: [("a", "1")])
+
+        XCTAssertEqual(duplicateRegistrationHandler.invocations.withLockedValue { $0 }.count, 0)
+    }
+}
+
+final class DuplicateRegistrationHandlerTests: XCTestCase {
+    func test_LoggingDuplicateRegistrationHandler() {
+        let recordingLogHandler = RecordingLogHandler()
+        LoggingSystem.bootstrap { _ in recordingLogHandler }
+        let handler = WarningDuplicateRegistrationHandler(logger: Logger(label: "test"))
+        handler.handle(
+            newRegistration: .counter(name: "name"),
+            existingRegistrations: [.gauge(name: "name"), .histogram(name: "name")]
+        )
+        let recordedLogMessages = recordingLogHandler.recordedLogMessages.withLockedValue { $0 }
+        XCTAssertEqual(recordedLogMessages.count, 1)
+        XCTAssertEqual(recordedLogMessages.first?.level, .warning)
+    }
+
+    func test_FatalErrorDuplicateRegistrationHandler() {
+        let handler = FatalErrorDuplicateRegistrationHandler()
+        XCTAssertThrowsFatalError {
+            handler.handle(
+                newRegistration: .counter(name: "name"),
+                existingRegistrations: [.gauge(name: "name"), .histogram(name: "name")]
+            )
+        }
+    }
+
+    func test_DuplicateRegistrationHandler_selection() {
+        XCTAssert(OTelMetricRegistry(onDuplicateRegistration: .warn).storage.withLockedValue { $0 }.duplicateRegistrationHandler is WarningDuplicateRegistrationHandler)
+        XCTAssert(OTelMetricRegistry(onDuplicateRegistration: .crash).storage.withLockedValue { $0 }.duplicateRegistrationHandler is FatalErrorDuplicateRegistrationHandler)
+    }
+
+    func test_DuplicateRegistrationHandler_default() {
+        XCTAssert(OTelMetricRegistry().storage.withLockedValue { $0 }.duplicateRegistrationHandler is WarningDuplicateRegistrationHandler)
+    }
+}


### PR DESCRIPTION
## Motivation

As part of the effort to provide an OLTP backend for Swift Metrics (see #84), we need some metric types and a registry. Since the intention is that these types support only the Swift Metics API (cf. the full OTel Metrics API), there's nothing that needs to be unique about them and they can be taken wholesale from another Swift Metrics backend package that has a good storage implementation, namely Swift Prometheus.

## Modifications

- Pull in the core metrics (Counter, Gauge, Histogram) and registry types from Swift Prometheus.
- Remove the Prometheus-specific emitting functionality.
- Add a NOTICE file that credits Swift Prometheus for these types.

## Result

Core metrics types exist, which can be wired up in either direction, both of which will be in subsequent pull requests:
1. To provide a Swift Metrics backend.
2. To export via OTLP.