### PR TITLE
[CI] Relax code coverage requirements

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,6 @@ coverage:
   status:
     project:
       default:
-        target: auto
         threshold: 5%
 
 ignore:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,3 +4,6 @@ coverage:
       default:
         target: auto
         threshold: 5%
+
+ignore:
+- Sources/OTelTesting


### PR DESCRIPTION
While it's nice to have Codecov complain about decreased coverage in a pull request, the defaults were too strict and made it impractical to satisfy.

This PR adds a `codecov.yml` file, setting the coverage threshold to 5%, meaning a single PR can decrease the overall coverage by up to 5%. It also configures Codecov to ignore code coverage of `OTelTesting` since this code is not intended to be used by library users but exists as a group of internal testing helpers.