### PR TITLE
Add OTLPMetricsFactory, a Swift Metrics backend

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),
 
         // MARK: - OTLP
 
@@ -40,6 +41,7 @@ let package = Package(
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
                 .product(name: "Atomics", package: "swift-atomics"),
+                .product(name: "CoreMetrics", package: "swift-metrics"),
             ],
             swiftSettings: sharedSwiftSettings
         ),

--- a/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
+++ b/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
@@ -95,6 +95,7 @@ public final class OTelMetricRegistry: Sendable {
                 }
                 let newInstrument = Counter(name: name, unit: unit, description: description, attributes: attributes)
                 existingInstruments[attributes] = newInstrument
+                storage.counters[identifier] = existingInstruments
                 return newInstrument
             }
             storage.register(identifier, forName: name)
@@ -113,6 +114,7 @@ public final class OTelMetricRegistry: Sendable {
                 }
                 let newInstrument = Gauge(name: name, unit: unit, description: description, attributes: attributes)
                 existingInstruments[attributes] = newInstrument
+                storage.gauges[identifier] = existingInstruments
                 return newInstrument
             }
             storage.register(identifier, forName: name)
@@ -131,6 +133,7 @@ public final class OTelMetricRegistry: Sendable {
                 }
                 let newInstrument = DurationHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
                 existingInstruments[attributes] = newInstrument
+                storage.durationHistograms[identifier] = existingInstruments
                 return newInstrument
             }
             storage.register(identifier, forName: name)
@@ -149,6 +152,7 @@ public final class OTelMetricRegistry: Sendable {
                 }
                 let newInstrument = ValueHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
                 existingInstruments[attributes] = newInstrument
+                storage.valueHistograms[identifier] = existingInstruments
                 return newInstrument
             }
             storage.register(identifier, forName: name)
@@ -166,6 +170,8 @@ public final class OTelMetricRegistry: Sendable {
                 if existingInstrument.isEmpty {
                     storage.counters.removeValue(forKey: identifier)
                     storage.unregister(identifier, forName: identifier.name)
+                } else {
+                    storage.counters[identifier] = existingInstrument
                 }
             }
         }
@@ -179,6 +185,8 @@ public final class OTelMetricRegistry: Sendable {
                 if existingInstrument.isEmpty {
                     storage.gauges.removeValue(forKey: identifier)
                     storage.unregister(identifier, forName: identifier.name)
+                } else {
+                    storage.gauges[identifier] = existingInstrument
                 }
             }
         }
@@ -192,6 +200,8 @@ public final class OTelMetricRegistry: Sendable {
                 if existingInstrument.isEmpty {
                     storage.durationHistograms.removeValue(forKey: identifier)
                     storage.unregister(identifier, forName: identifier.name)
+                } else {
+                    storage.durationHistograms[identifier] = existingInstrument
                 }
             }
         }
@@ -205,6 +215,8 @@ public final class OTelMetricRegistry: Sendable {
                 if existingInstrument.isEmpty {
                     storage.valueHistograms.removeValue(forKey: identifier)
                     storage.unregister(identifier, forName: identifier.name)
+                } else {
+                    storage.valueHistograms[identifier] = existingInstrument
                 }
             }
         }

--- a/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
+++ b/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
@@ -18,6 +18,7 @@ import struct NIOConcurrencyHelpers.NIOLockedValueBox
 ///
 /// The registry owns the mapping from instrument identfier and attributes to the stateful instrument for recording
 /// measurements.
+@_spi(Metrics)
 public final class OTelMetricRegistry: Sendable {
     private let logger = Logger(label: "OTelMetricRegistry")
 

--- a/Sources/OTel/Metrics/SwiftMetricsFactory/Counter+SwiftMetrics.swift
+++ b/Sources/OTel/Metrics/SwiftMetricsFactory/Counter+SwiftMetrics.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CoreMetrics
+
+extension Counter: CoreMetrics.CounterHandler {}
+
+extension Counter: CoreMetrics.FloatingPointCounterHandler {}

--- a/Sources/OTel/Metrics/SwiftMetricsFactory/Gauge+SwiftMetrics.swift
+++ b/Sources/OTel/Metrics/SwiftMetricsFactory/Gauge+SwiftMetrics.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CoreMetrics
+
+extension Gauge: CoreMetrics.RecorderHandler {
+    func record(_ value: Int64) {
+        record(Double(value))
+    }
+
+    func record(_ value: Double) {
+        set(to: value)
+    }
+}
+
+extension Gauge: CoreMetrics.MeterHandler {
+    func set(_ value: Double) {
+        set(to: value)
+    }
+
+    func set(_ value: Int64) {
+        set(to: Double(value))
+    }
+}

--- a/Sources/OTel/Metrics/SwiftMetricsFactory/Histogram+SwiftMetrics.swift
+++ b/Sources/OTel/Metrics/SwiftMetricsFactory/Histogram+SwiftMetrics.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CoreMetrics
+
+extension Histogram: _SwiftMetricsSendableProtocol {}
+
+extension Histogram: CoreMetrics.TimerHandler where Value == Duration {
+    func recordNanoseconds(_ duration: Int64) {
+        let value = Duration.nanoseconds(duration)
+        record(value)
+    }
+}
+
+extension Histogram: CoreMetrics.RecorderHandler where Value == Double {
+    func record(_ value: Int64) {
+        record(Double(value))
+    }
+}

--- a/Sources/OTel/Metrics/SwiftMetricsFactory/OTLPMetricsFactory.swift
+++ b/Sources/OTel/Metrics/SwiftMetricsFactory/OTLPMetricsFactory.swift
@@ -1,0 +1,191 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftPrometheus open source project
+//
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftPrometheus project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CoreMetrics
+
+/// A Swift Metrics `MetricsFactory` implementation backed by ``OTelMetricRegistry``.
+///
+/// - TODO: Review the API surface we want to provide.
+///
+///   Right now, this is a wrapper type around the ``OTelMetricRegistry`` which adds some configuration. The API is
+///   similar to what is in Swift Prometheus, but we might not need to layer this way.
+///
+///   Specifically, Swift Prometheus provides public API on the registry itself for directly creating and exporting
+///   metrics, without using the Swift Metrics API.
+///
+///   Currently, the registry in this package is opaque, which begs the question: maybe the registry type should be
+///   internal and we just have this factory be the public API for now and defer making the registry public to if/when
+///   we want to extend this package to provide direct OTel funcionality.
+@_spi(Metrics)
+public struct OTLPMetricsFactory: Sendable {
+    private static let _defaultRegistry = OTelMetricRegistry()
+
+    /// The shared, default registry.
+    public static var defaultRegistry: OTelMetricRegistry {
+        _defaultRegistry
+    }
+
+    /// The underlying registry that provides the handler for the Swift Metrics API.
+    public var registry: OTelMetricRegistry
+
+    /// The default bucket upper bounds for duration histograms created for a Swift Metrics `Timer`.
+    public var defaultDurationHistogramBuckets: [Duration]
+
+    /// The bucket upper bounds for duration histograms created for a Swift Metrics `Timer` with a specific label.
+    public var durationHistogramBuckets: [String: [Duration]]
+
+    /// The default bucket upper bounds for value histograms created for a Swift Metrics `Recorder`.
+    public var defaultValueHistogramBuckets: [Double]
+
+    /// The bucket upper bounds for value histograms created for a Swift Metrics `Recorder` with a specific label.
+    public var valueHistogramBuckets: [String: [Double]]
+
+    /// A closure to modify the name and labels used in the Swift Metrics API.
+    ///
+    /// This allows users to override the metadata for metrics recorded by third party packages.
+    public var nameAndLabelSanitizer: @Sendable (_ name: String, _ labels: [(String, String)]) -> (String, [(String, String)])
+
+    /// Create a new ``OTLPMetricsFactory``.
+    ///
+    /// - Parameter registry: The registry for metric instruments.
+    public init(registry: OTelMetricRegistry = Self.defaultRegistry) {
+        self.registry = registry
+
+        durationHistogramBuckets = [:]
+        defaultDurationHistogramBuckets = [
+            .zero,
+            .milliseconds(5),
+            .milliseconds(10),
+            .milliseconds(25),
+            .milliseconds(50),
+            .milliseconds(75),
+            .milliseconds(100),
+            .milliseconds(250),
+            .milliseconds(500),
+            .milliseconds(750),
+            .milliseconds(1000),
+            .milliseconds(2500),
+            .milliseconds(5000),
+            .milliseconds(7500),
+            .milliseconds(10000),
+        ]
+
+        valueHistogramBuckets = [:]
+        defaultValueHistogramBuckets = [
+            0,
+            5,
+            10,
+            25,
+            50,
+            75,
+            100,
+            250,
+            500,
+            750,
+            1000,
+            2500,
+            5000,
+            7500,
+            10000,
+        ]
+
+        nameAndLabelSanitizer = { ($0, $1) }
+    }
+}
+
+extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
+    public func makeCounter(label: String, dimensions: [(String, String)]) -> CoreMetrics.CounterHandler {
+        let (label, dimensions) = nameAndLabelSanitizer(label, dimensions)
+        return registry.makeCounter(name: label, labels: dimensions)
+    }
+
+    public func makeFloatingPointCounter(label: String, dimensions: [(String, String)]) -> CoreMetrics.FloatingPointCounterHandler {
+        let (label, dimensions) = nameAndLabelSanitizer(label, dimensions)
+        return registry.makeCounter(name: label, labels: dimensions)
+    }
+
+    public func makeRecorder(
+        label: String,
+        dimensions: [(String, String)],
+        aggregate: Bool
+    ) -> CoreMetrics.RecorderHandler {
+        let (label, dimensions) = nameAndLabelSanitizer(label, dimensions)
+        guard aggregate else {
+            return registry.makeGauge(name: label, labels: dimensions)
+        }
+        let buckets = valueHistogramBuckets[label] ?? defaultValueHistogramBuckets
+        return registry.makeValueHistogram(name: label, labels: dimensions, buckets: buckets)
+    }
+
+    public func makeMeter(label: String, dimensions: [(String, String)]) -> CoreMetrics.MeterHandler {
+        registry.makeGauge(name: label, labels: dimensions)
+    }
+
+    public func makeTimer(label: String, dimensions: [(String, String)]) -> CoreMetrics.TimerHandler {
+        let (label, dimensions) = nameAndLabelSanitizer(label, dimensions)
+        let buckets = durationHistogramBuckets[label] ?? defaultDurationHistogramBuckets
+        return registry.makeDurationHistogram(name: label, labels: dimensions, buckets: buckets)
+    }
+
+    public func destroyCounter(_ handler: CoreMetrics.CounterHandler) {
+        guard let counter = handler as? Counter else {
+            return
+        }
+        registry.unregisterCounter(counter)
+    }
+
+    public func destroyFloatingPointCounter(_ handler: FloatingPointCounterHandler) {
+        guard let counter = handler as? Counter else {
+            return
+        }
+        registry.unregisterCounter(counter)
+    }
+
+    public func destroyRecorder(_ handler: CoreMetrics.RecorderHandler) {
+        switch handler {
+        case let gauge as Gauge:
+            registry.unregisterGauge(gauge)
+        case let histogram as Histogram<Double>:
+            registry.unregisterValueHistogram(histogram)
+        default:
+            break
+        }
+    }
+
+    public func destroyMeter(_ handler: CoreMetrics.MeterHandler) {
+        guard let gauge = handler as? Gauge else {
+            return
+        }
+        registry.unregisterGauge(gauge)
+    }
+
+    public func destroyTimer(_ handler: CoreMetrics.TimerHandler) {
+        guard let histogram = handler as? Histogram<Duration> else {
+            return
+        }
+        registry.unregisterDurationHistogram(histogram)
+    }
+}

--- a/Sources/OTelTesting/Metrics+TestHelpers.swift
+++ b/Sources/OTelTesting/Metrics+TestHelpers.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import XCTest
+
+extension Counter {
+    private var integerAtomicValue: Int64 { intAtomic.load(ordering: .relaxed) }
+    private var doubleAtomicValue: Double { Double(bitPattern: floatAtomic.load(ordering: .relaxed)) }
+
+    package func assertStateEquals(integerPart: Int64, doublePart: Double, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(integerAtomicValue, integerPart, "Unexpected integer part", file: file, line: line)
+        XCTAssertEqual(doubleAtomicValue, doublePart, "Unexpected double part", file: file, line: line)
+    }
+}
+
+extension Gauge {
+    package var doubleAtomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
+}
+
+extension Histogram {
+    private struct EquatableBucket: Equatable {
+        var bound: Value
+        var count: Int
+    }
+
+    package func assertStateEquals(
+        count: Int,
+        sum: Value,
+        buckets: [(bound: Value, count: Int)],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let state = box.withLockedValue { $0 }
+        XCTAssertEqual(state.count, count, "Unexpected count", file: file, line: line)
+        XCTAssertEqual(state.sum, sum, "Unexpected sum", file: file, line: line)
+        XCTAssertEqual(
+            state.buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
+            buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
+            "Unexpected buckets",
+            file: file, line: line
+        )
+    }
+}

--- a/Tests/OTelTests/Metrics/MetricStore/CounterTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/CounterTests.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import OTel
+import OTelTesting
 import XCTest
 
 final class CounterTests: XCTestCase {
@@ -53,15 +54,5 @@ final class CounterTests: XCTestCase {
             }
         }
         counter.assertStateEquals(integerPart: 100_000, doublePart: 100_000)
-    }
-}
-
-extension Counter {
-    private var integerAtomicValue: Int64 { intAtomic.load(ordering: .relaxed) }
-    private var doubleAtomicValue: Double { Double(bitPattern: floatAtomic.load(ordering: .relaxed)) }
-
-    fileprivate func assertStateEquals(integerPart: Int64, doublePart: Double, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(integerAtomicValue, integerPart, "Unexpected integer part", file: file, line: line)
-        XCTAssertEqual(doubleAtomicValue, doublePart, "Unexpected double part", file: file, line: line)
     }
 }

--- a/Tests/OTelTests/Metrics/MetricStore/HistogramTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/HistogramTests.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import OTel
+import OTelTesting
 import XCTest
 
 final class HistogramTests: XCTestCase {
@@ -22,8 +23,7 @@ final class HistogramTests: XCTestCase {
             .milliseconds(500),
             .seconds(1),
         ])
-        histogram.box.withLockedValue { _ in
-        }
+
         histogram.assertStateEquals(count: 0, sum: .zero, buckets: [
             (bound: .milliseconds(100), count: 0),
             (bound: .milliseconds(250), count: 0),
@@ -117,30 +117,5 @@ final class HistogramTests: XCTestCase {
         }
         XCTAssert(Double.nan.bucketRepresentation.isNaN)
         XCTAssert(Double.signalingNaN.bucketRepresentation.isSignalingNaN)
-    }
-}
-
-extension DurationHistogram {
-    fileprivate struct EquatableBucket: Equatable {
-        var bound: Duration
-        var count: Int
-    }
-
-    fileprivate func assertStateEquals(
-        count: Int,
-        sum: Duration,
-        buckets: [(bound: Duration, count: Int)],
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        let state = box.withLockedValue { $0 }
-        XCTAssertEqual(state.count, count, "Unexpected count", file: file, line: line)
-        XCTAssertEqual(state.sum, sum, "Unexpected sum", file: file, line: line)
-        XCTAssertEqual(
-            state.buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
-            buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
-            "Unexpected buckets",
-            file: file, line: line
-        )
     }
 }

--- a/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
@@ -79,7 +79,7 @@ final class OTelMetricRegistryTests: XCTestCase {
         )
     }
 
-    func test_identity_sameNameDifferentOrder_identical() {
+    func test_identity_sameNameDifferentLabelOrder_identical() {
         let registry = OTelMetricRegistry()
         XCTAssertIdentical(
             registry.makeCounter(name: "c", labels: [("one", "1"), ("two", "2")]),
@@ -281,6 +281,107 @@ final class OTelMetricRegistryTests: XCTestCase {
 
         XCTAssertEqual(duplicateRegistrationHandler.invocations.withLockedValue { $0 }.count, 0)
     }
+
+    func test_makeCounter_retainsAllMadeInstruments() {
+        let registry = OTelMetricRegistry()
+        XCTAssertEqual(registry.numDistinctInstruments, 0)
+        _ = registry.makeCounter(name: "c1")
+        _ = registry.makeCounter(name: "c1")
+        _ = registry.makeCounter(name: "c1", labels: [])
+        _ = registry.makeCounter(name: "c1", labels: [])
+        XCTAssertEqual(registry.numDistinctInstruments, 1)
+        _ = registry.makeCounter(name: "c1", labels: [("x", "1")])
+        _ = registry.makeCounter(name: "c1", labels: [("x", "1")])
+        XCTAssertEqual(registry.numDistinctInstruments, 2)
+        _ = registry.makeCounter(name: "c1", labels: [("x", "2")])
+        _ = registry.makeCounter(name: "c1", labels: [("x", "2")])
+        XCTAssertEqual(registry.numDistinctInstruments, 3)
+        _ = registry.makeCounter(name: "c1", labels: [("y", "1")])
+        _ = registry.makeCounter(name: "c1", labels: [("y", "1")])
+        XCTAssertEqual(registry.numDistinctInstruments, 4)
+        _ = registry.makeCounter(name: "c2")
+        _ = registry.makeCounter(name: "c2")
+        XCTAssertEqual(registry.numDistinctInstruments, 5)
+    }
+
+    func test_makeGauge_retainsAllMadeInstruments() {
+        let registry = OTelMetricRegistry()
+        _ = registry.makeGauge(name: "g1")
+        _ = registry.makeGauge(name: "g1")
+        _ = registry.makeGauge(name: "g1", labels: [])
+        _ = registry.makeGauge(name: "g1", labels: [])
+        XCTAssertEqual(registry.numDistinctInstruments, 1)
+        _ = registry.makeGauge(name: "g1", labels: [("x", "1")])
+        _ = registry.makeGauge(name: "g1", labels: [("x", "1")])
+        XCTAssertEqual(registry.numDistinctInstruments, 2)
+        _ = registry.makeGauge(name: "g1", labels: [("x", "2")])
+        _ = registry.makeGauge(name: "g1", labels: [("x", "2")])
+        XCTAssertEqual(registry.numDistinctInstruments, 3)
+        _ = registry.makeGauge(name: "g1", labels: [("y", "1")])
+        _ = registry.makeGauge(name: "g1", labels: [("y", "1")])
+        XCTAssertEqual(registry.numDistinctInstruments, 4)
+        _ = registry.makeGauge(name: "g2")
+        _ = registry.makeGauge(name: "g2")
+        XCTAssertEqual(registry.numDistinctInstruments, 5)
+    }
+
+    func test_makeValueHistogram_retainsAllMadeInstruments() {
+        let registry = OTelMetricRegistry()
+        _ = registry.makeValueHistogram(name: "v1", buckets: [])
+        _ = registry.makeValueHistogram(name: "v1", buckets: [])
+        _ = registry.makeValueHistogram(name: "v1", labels: [], buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", labels: [], buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", labels: [], buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", labels: [], buckets: [1, 2])
+        XCTAssertEqual(registry.numDistinctInstruments, 1)
+        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "1")], buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "1")], buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "1")], buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "1")], buckets: [1, 2])
+        XCTAssertEqual(registry.numDistinctInstruments, 2)
+        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "2")], buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "2")], buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "2")], buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "2")], buckets: [1, 2])
+        XCTAssertEqual(registry.numDistinctInstruments, 3)
+        _ = registry.makeValueHistogram(name: "v1", labels: [("y", "1")], buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", labels: [("y", "1")], buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", labels: [("y", "1")], buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", labels: [("y", "1")], buckets: [1, 2])
+        XCTAssertEqual(registry.numDistinctInstruments, 4)
+        _ = registry.makeValueHistogram(name: "v2", buckets: [])
+        _ = registry.makeValueHistogram(name: "v2", buckets: [])
+        XCTAssertEqual(registry.numDistinctInstruments, 5)
+    }
+
+    func test_makeDurationHistogram_retainsAllMadeInstruments() {
+        let registry = OTelMetricRegistry()
+        _ = registry.makeDurationHistogram(name: "d1", buckets: [])
+        _ = registry.makeDurationHistogram(name: "d1", buckets: [])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [], buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [], buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [], buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [], buckets: [.seconds(2)])
+        XCTAssertEqual(registry.numDistinctInstruments, 1)
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "1")], buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "1")], buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "1")], buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "1")], buckets: [.seconds(2)])
+        XCTAssertEqual(registry.numDistinctInstruments, 2)
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "2")], buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "2")], buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "2")], buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "2")], buckets: [.seconds(2)])
+        XCTAssertEqual(registry.numDistinctInstruments, 3)
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("y", "1")], buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("y", "1")], buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("y", "1")], buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", labels: [("y", "1")], buckets: [.seconds(2)])
+        XCTAssertEqual(registry.numDistinctInstruments, 4)
+        _ = registry.makeDurationHistogram(name: "d2", buckets: [])
+        _ = registry.makeDurationHistogram(name: "d2", buckets: [])
+        XCTAssertEqual(registry.numDistinctInstruments, 5)
+    }
 }
 
 final class DuplicateRegistrationHandlerTests: XCTestCase {
@@ -314,5 +415,18 @@ final class DuplicateRegistrationHandlerTests: XCTestCase {
 
     func test_DuplicateRegistrationHandler_default() {
         XCTAssert(OTelMetricRegistry().storage.withLockedValue { $0 }.duplicateRegistrationHandler is WarningDuplicateRegistrationHandler)
+    }
+}
+
+extension OTelMetricRegistry {
+    var numDistinctInstruments: Int {
+        let metrics = storage.withLockedValue { $0 }
+        let x: [Int] = [
+            metrics.counters.values.map(\.values.count).reduce(0, +),
+            metrics.gauges.values.map(\.values.count).reduce(0, +),
+            metrics.durationHistograms.values.map(\.values.count).reduce(0, +),
+            metrics.valueHistograms.values.map(\.values.count).reduce(0, +),
+        ]
+        return x.reduce(0, +)
     }
 }

--- a/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
@@ -13,7 +13,7 @@
 
 import Logging
 import struct NIOConcurrencyHelpers.NIOLockedValueBox
-@testable import OTel
+@testable @_spi(Metrics) import OTel
 import OTelTesting
 import XCTest
 

--- a/Tests/OTelTests/Metrics/SwiftMetricsFactory/OTLPMetricsFactoryTests.swift
+++ b/Tests/OTelTests/Metrics/SwiftMetricsFactory/OTLPMetricsFactoryTests.swift
@@ -1,0 +1,436 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CoreMetrics
+@testable @_spi(Metrics) import OTel
+import OTelTesting
+import XCTest
+
+final class OTLPMetricsFactoryTests: XCTestCase {
+    func test_makeCounter_returnsOTelCounter() throws {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        let counter = try XCTUnwrap(factory.makeCounter(label: "c", dimensions: [("x", "1")]) as? OTel.Counter)
+        XCTAssertEqual(counter.name, "c")
+        XCTAssertEqual(counter.attributes, Set([("x", "1")]))
+    }
+
+    func test_makeFloatingPointCounter_returnsOTelCounter() throws {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        let counter = try XCTUnwrap(factory.makeFloatingPointCounter(label: "c", dimensions: [("x", "1")]) as? OTel.Counter)
+        XCTAssertEqual(counter.name, "c")
+        XCTAssertEqual(counter.attributes, Set([("x", "1")]))
+    }
+
+    func testMakeCounterAndMakeFloatingPointCounterReturnSameOTelCounter() throws {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        XCTAssertIdentical(
+            factory.makeCounter(label: "c", dimensions: [("x", "1")]),
+            factory.makeFloatingPointCounter(label: "c", dimensions: [("x", "1")])
+        )
+    }
+
+    func test_makeMeter_returnsOTelGauge() throws {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        let meter = factory.makeMeter(label: "m", dimensions: [("x", "1")])
+        let gauge = try XCTUnwrap(meter as? OTel.Gauge)
+        XCTAssertEqual(gauge.name, "m")
+        XCTAssertEqual(gauge.attributes, Set([("x", "1")]))
+    }
+
+    func test_makeTimer_returnsOTelDurationHistogram() throws {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        let timer = factory.makeTimer(label: "t", dimensions: [("x", "1")])
+        let histogram = try XCTUnwrap(timer as? DurationHistogram)
+        XCTAssertEqual(histogram.name, "t")
+        XCTAssertEqual(histogram.attributes, Set([("x", "1")]))
+    }
+
+    func test_makeRecorderWithoutAggregation_returnsOTelGauge() throws {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        let recorder = factory.makeRecorder(label: "r", dimensions: [("x", "1")], aggregate: false)
+        let gauge = try XCTUnwrap(recorder as? OTel.Gauge)
+        XCTAssertEqual(gauge.name, "r")
+        XCTAssertEqual(gauge.attributes, Set([("x", "1")]))
+    }
+
+    func test_makeRecorderWithAggregation_returnsOTelValueHistogram() throws {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        let recorder = factory.makeRecorder(label: "r", dimensions: [("x", "1")], aggregate: true)
+        let histogram = try XCTUnwrap(recorder as? ValueHistogram)
+        XCTAssertEqual(histogram.name, "r")
+        XCTAssertEqual(histogram.attributes, Set([("x", "1")]))
+    }
+
+    func test_makeTimer_customBuckets() throws {
+        let registry = OTelMetricRegistry()
+        var factory = OTLPMetricsFactory(registry: registry)
+        factory.defaultDurationHistogramBuckets = [.milliseconds(100), .milliseconds(200)]
+        factory.durationHistogramBuckets = ["custom": [.milliseconds(300), .milliseconds(400)]]
+
+        do {
+            let timer = factory.makeTimer(label: "default", dimensions: [])
+            let histogram = try XCTUnwrap(timer as? DurationHistogram)
+            histogram.assertStateEquals(count: 0, sum: .zero, buckets: [
+                (bound: .milliseconds(100), count: 0),
+                (bound: .milliseconds(200), count: 0),
+            ])
+        }
+
+        do {
+            let timer = factory.makeTimer(label: "custom", dimensions: [])
+            let histogram = try XCTUnwrap(timer as? DurationHistogram)
+            histogram.assertStateEquals(count: 0, sum: .zero, buckets: [
+                (bound: .milliseconds(300), count: 0),
+                (bound: .milliseconds(400), count: 0),
+            ])
+        }
+    }
+
+    func test_makeRecorder_customBuckets() throws {
+        let registry = OTelMetricRegistry()
+        var factory = OTLPMetricsFactory(registry: registry)
+        factory.defaultValueHistogramBuckets = [0.1, 0.2]
+        factory.valueHistogramBuckets = ["custom": [0.3, 0.4]]
+
+        do {
+            let recorder = factory.makeRecorder(label: "default", dimensions: [], aggregate: true)
+            let histogram = try XCTUnwrap(recorder as? ValueHistogram)
+            histogram.assertStateEquals(count: 0, sum: 0, buckets: [
+                (bound: 0.1, count: 0),
+                (bound: 0.2, count: 0),
+            ])
+        }
+
+        do {
+            let recorder = factory.makeRecorder(label: "custom", dimensions: [], aggregate: true)
+            let histogram = try XCTUnwrap(recorder as? ValueHistogram)
+            histogram.assertStateEquals(count: 0, sum: 0, buckets: [
+                (bound: 0.3, count: 0),
+                (bound: 0.4, count: 0),
+            ])
+        }
+    }
+
+    func test_Counter_methods() {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+        let counter = factory.makeCounter(label: "c", dimensions: [("x", "1")])
+
+        (counter as? OTel.Counter)?.assertStateEquals(integerPart: 0, doublePart: 0.0)
+        counter.increment(by: 2)
+        (counter as? OTel.Counter)?.assertStateEquals(integerPart: 2, doublePart: 0.0)
+        counter.increment(by: 2)
+        (counter as? OTel.Counter)?.assertStateEquals(integerPart: 4, doublePart: 0.0)
+        counter.reset()
+        (counter as? OTel.Counter)?.assertStateEquals(integerPart: 0, doublePart: 0.0)
+    }
+
+    func test_FloatingPointCounter_methods() {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+        let counter = factory.makeFloatingPointCounter(label: "c", dimensions: [("x", "1")])
+
+        (counter as? OTel.Counter)?.assertStateEquals(integerPart: 0, doublePart: 0.0)
+        counter.increment(by: 2)
+        (counter as? OTel.Counter)?.assertStateEquals(integerPart: 0, doublePart: 2.0)
+        counter.increment(by: Double(2.5))
+        (counter as? OTel.Counter)?.assertStateEquals(integerPart: 0, doublePart: 4.5)
+        counter.reset()
+        (counter as? OTel.Counter)?.assertStateEquals(integerPart: 0, doublePart: 0.0)
+    }
+
+    func test_Meter_methods() {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+        let meter = factory.makeMeter(label: "m", dimensions: [("x", "1")])
+
+        meter.set(43.5)
+        XCTAssertEqual((meter as? OTel.Gauge)?.doubleAtomicValue, 43.5)
+        meter.increment(by: 6.5)
+        XCTAssertEqual((meter as? OTel.Gauge)?.doubleAtomicValue, 50.0)
+        meter.decrement(by: 8.0)
+        XCTAssertEqual((meter as? OTel.Gauge)?.doubleAtomicValue, 42.0)
+        meter.set(Int64(6))
+        XCTAssertEqual((meter as? OTel.Gauge)?.doubleAtomicValue, 6.0)
+    }
+
+    func test_Recorder_withoutAggregration_methods() throws {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+        let recorder = factory.makeRecorder(label: "r", dimensions: [("x", "1")], aggregate: false)
+
+        XCTAssertEqual((recorder as? OTel.Gauge)?.doubleAtomicValue, 0.0)
+        recorder.record(Int64(2))
+        XCTAssertEqual((recorder as? OTel.Gauge)?.doubleAtomicValue, 2.0)
+        recorder.record(Double(-3.1))
+        XCTAssertEqual((recorder as? OTel.Gauge)?.doubleAtomicValue, -3.1)
+        recorder.record(Int64(42))
+        XCTAssertEqual((recorder as? OTel.Gauge)?.doubleAtomicValue, 42)
+    }
+
+    func test_Recorder_withAggregration_methods() throws {
+        let registry = OTelMetricRegistry()
+        var factory = OTLPMetricsFactory(registry: registry)
+        factory.defaultValueHistogramBuckets = [0.1, 0.25, 0.5, 1]
+        let recorder = factory.makeRecorder(label: "r", dimensions: [("x", "1")], aggregate: true)
+
+        (recorder as? ValueHistogram)?.assertStateEquals(count: 0, sum: 0, buckets: [
+            (bound: 0.10, count: 0),
+            (bound: 0.25, count: 0),
+            (bound: 0.50, count: 0),
+            (bound: 1.00, count: 0),
+        ])
+
+        recorder.record(0.4)
+        (recorder as? ValueHistogram)?.assertStateEquals(count: 1, sum: 0.4, buckets: [
+            (bound: 0.10, count: 0),
+            (bound: 0.25, count: 0),
+            (bound: 0.50, count: 1),
+            (bound: 1.00, count: 1),
+        ])
+
+        recorder.record(0.6)
+        (recorder as? ValueHistogram)?.assertStateEquals(count: 2, sum: 1.0, buckets: [
+            (bound: 0.10, count: 0),
+            (bound: 0.25, count: 0),
+            (bound: 0.50, count: 1),
+            (bound: 1.00, count: 2),
+        ])
+
+        recorder.record(1.2)
+        (recorder as? ValueHistogram)?.assertStateEquals(count: 3, sum: 2.2, buckets: [
+            (bound: 0.10, count: 0),
+            (bound: 0.25, count: 0),
+            (bound: 0.50, count: 1),
+            (bound: 1.00, count: 2),
+        ])
+
+        recorder.record(0.01)
+        (recorder as? ValueHistogram)?.assertStateEquals(count: 4, sum: 2.21, buckets: [
+            (bound: 0.10, count: 1),
+            (bound: 0.25, count: 1),
+            (bound: 0.50, count: 2),
+            (bound: 1.00, count: 3),
+        ])
+
+        recorder.record(Int64(1))
+        (recorder as? ValueHistogram)?.assertStateEquals(count: 5, sum: 3.21, buckets: [
+            (bound: 0.10, count: 1),
+            (bound: 0.25, count: 1),
+            (bound: 0.50, count: 2),
+            (bound: 1.00, count: 4),
+        ])
+
+        recorder.record(Int64(2))
+        (recorder as? ValueHistogram)?.assertStateEquals(count: 6, sum: 5.21, buckets: [
+            (bound: 0.10, count: 1),
+            (bound: 0.25, count: 1),
+            (bound: 0.50, count: 2),
+            (bound: 1.00, count: 4),
+        ])
+    }
+
+    func test_Timer_methods() throws {
+        let registry = OTelMetricRegistry()
+        var factory = OTLPMetricsFactory(registry: registry)
+        factory.defaultDurationHistogramBuckets = [
+            .nanoseconds(100),
+            .nanoseconds(250),
+            .nanoseconds(500),
+            .microseconds(1),
+        ]
+        let timer = factory.makeTimer(label: "t", dimensions: [("x", "1")])
+
+        (timer as? DurationHistogram)?.assertStateEquals(count: 0, sum: .zero, buckets: [
+            (bound: .nanoseconds(100), count: 0),
+            (bound: .nanoseconds(250), count: 0),
+            (bound: .nanoseconds(500), count: 0),
+            (bound: .microseconds(1), count: 0),
+        ])
+
+        timer.recordNanoseconds(400)
+        (timer as? DurationHistogram)?.assertStateEquals(count: 1, sum: .nanoseconds(400), buckets: [
+            (bound: .nanoseconds(100), count: 0),
+            (bound: .nanoseconds(250), count: 0),
+            (bound: .nanoseconds(500), count: 1),
+            (bound: .microseconds(1), count: 1),
+        ])
+
+        timer.recordNanoseconds(600)
+        (timer as? DurationHistogram)?.assertStateEquals(count: 2, sum: .nanoseconds(1000), buckets: [
+            (bound: .nanoseconds(100), count: 0),
+            (bound: .nanoseconds(250), count: 0),
+            (bound: .nanoseconds(500), count: 1),
+            (bound: .microseconds(1), count: 2),
+        ])
+
+        timer.recordNanoseconds(1200)
+        (timer as? DurationHistogram)?.assertStateEquals(count: 3, sum: .nanoseconds(2200), buckets: [
+            (bound: .nanoseconds(100), count: 0),
+            (bound: .nanoseconds(250), count: 0),
+            (bound: .nanoseconds(500), count: 1),
+            (bound: .microseconds(1), count: 2),
+        ])
+
+        timer.recordNanoseconds(80)
+        (timer as? DurationHistogram)?.assertStateEquals(count: 4, sum: .nanoseconds(2280), buckets: [
+            (bound: .nanoseconds(100), count: 1),
+            (bound: .nanoseconds(250), count: 1),
+            (bound: .nanoseconds(500), count: 2),
+            (bound: .microseconds(1), count: 3),
+        ])
+    }
+
+    func test_reregister_withoutDimensions() {
+        let duplicateRegistrationHandler = RecordingDuplicateRegistrationHandler()
+        let registry = OTelMetricRegistry(duplicateRegistrationHandler: duplicateRegistrationHandler)
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        // Here we test a few things at once:
+        // 1. That we can destroy using the handler.
+        // 2. That double destroy is OK (i.e. doesn't crash).
+        // 3. That, once destroyed, we can reuse the handle.
+        // 4. That the reuse did not result in a duplicate registration handler call.
+
+        let c = factory.makeCounter(label: "name", dimensions: [])
+        factory.destroyCounter(c)
+        factory.destroyCounter(c)
+
+        let f = factory.makeFloatingPointCounter(label: "name", dimensions: [])
+        factory.destroyFloatingPointCounter(f)
+        factory.destroyFloatingPointCounter(f)
+
+        let m = factory.makeMeter(label: "name", dimensions: [])
+        factory.destroyMeter(m)
+        factory.destroyMeter(m)
+
+        let r = factory.makeRecorder(label: "name", dimensions: [], aggregate: true)
+        factory.destroyRecorder(r)
+        factory.destroyRecorder(r)
+
+        let r_ = factory.makeRecorder(label: "name", dimensions: [], aggregate: false)
+        factory.destroyRecorder(r_)
+        factory.destroyRecorder(r_)
+
+        let t = factory.makeTimer(label: "name", dimensions: [])
+        factory.destroyTimer(t)
+        factory.destroyTimer(t)
+
+        _ = factory.makeCounter(label: "name", dimensions: [])
+
+        XCTAssertEqual(duplicateRegistrationHandler.invocations.withLockedValue { $0 }.count, 0)
+    }
+
+    func test_reregister_withDimensions() {
+        let duplicateRegistrationHandler = RecordingDuplicateRegistrationHandler()
+        let registry = OTelMetricRegistry(duplicateRegistrationHandler: duplicateRegistrationHandler)
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        let c1 = factory.makeCounter(label: "name", dimensions: [("a", "1")])
+        let c2 = factory.makeCounter(label: "name", dimensions: [("b", "1")])
+        factory.destroyCounter(c1)
+        factory.destroyCounter(c1)
+        factory.destroyCounter(c2)
+        factory.destroyCounter(c2)
+        XCTAssert(registry.storage.withLockedValue { $0 }.registrations.isEmpty)
+
+        let f1 = factory.makeFloatingPointCounter(label: "name", dimensions: [("a", "1")])
+        let f2 = factory.makeFloatingPointCounter(label: "name", dimensions: [("b", "1")])
+        factory.destroyFloatingPointCounter(f1)
+        factory.destroyFloatingPointCounter(f1)
+        factory.destroyFloatingPointCounter(f2)
+        factory.destroyFloatingPointCounter(f2)
+        XCTAssert(registry.storage.withLockedValue { $0 }.registrations.isEmpty)
+
+        let m1 = factory.makeMeter(label: "name", dimensions: [("a", "1")])
+        let m2 = factory.makeMeter(label: "name", dimensions: [("b", "1")])
+        factory.destroyMeter(m1)
+        factory.destroyMeter(m1)
+        factory.destroyMeter(m2)
+        factory.destroyMeter(m2)
+        XCTAssert(registry.storage.withLockedValue { $0 }.registrations.isEmpty)
+
+        let r1 = factory.makeRecorder(label: "name", dimensions: [("a", "1")], aggregate: true)
+        let r2 = factory.makeRecorder(label: "name", dimensions: [("b", "1")], aggregate: true)
+        factory.destroyRecorder(r1)
+        factory.destroyRecorder(r1)
+        factory.destroyRecorder(r2)
+        factory.destroyRecorder(r2)
+        XCTAssert(registry.storage.withLockedValue { $0 }.registrations.isEmpty)
+
+        let t1 = factory.makeTimer(label: "name", dimensions: [("a", "1")])
+        let t2 = factory.makeTimer(label: "name", dimensions: [("b", "1")])
+        factory.destroyTimer(t1)
+        factory.destroyTimer(t1)
+        factory.destroyTimer(t2)
+        factory.destroyTimer(t2)
+        XCTAssert(registry.storage.withLockedValue { $0 }.registrations.isEmpty)
+
+        _ = factory.makeCounter(label: "name", dimensions: [])
+
+        XCTAssertEqual(registry.storage.withLockedValue { $0 }.registrations.count, 1)
+        XCTAssertEqual(duplicateRegistrationHandler.invocations.withLockedValue { $0 }.count, 0)
+    }
+
+    func test_FactoryInitializer_usesSingletonRegistryByDefault() {
+        XCTAssertIdentical(
+            OTLPMetricsFactory().registry,
+            OTLPMetricsFactory().registry
+        )
+    }
+
+    func test_destroy_gracefullyHandlesBogusHandles() {
+        let registry = OTelMetricRegistry()
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        final class NonOTelMetricsHandler: CounterHandler, FloatingPointCounterHandler, MeterHandler, RecorderHandler, TimerHandler {
+            func decrement(by: Double) {}
+            func increment(by: Int64) {}
+            func increment(by: Double) {}
+            func record(_ value: Int64) {}
+            func record(_ value: Double) {}
+            func recordNanoseconds(_ duration: Int64) {}
+            func reset() {}
+            func set(_ value: Int64) {}
+            func set(_ value: Double) {}
+        }
+
+        factory.destroyCounter(NonOTelMetricsHandler())
+        factory.destroyFloatingPointCounter(NonOTelMetricsHandler())
+        factory.destroyMeter(NonOTelMetricsHandler())
+        factory.destroyRecorder(NonOTelMetricsHandler())
+        factory.destroyTimer(NonOTelMetricsHandler())
+    }
+
+    func test_defaultHistogramBuckets_matchOTelSpecification() {
+        // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation
+        let defaultBucketsFromOTelSpec = [0.0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]
+        let factory = OTLPMetricsFactory()
+        XCTAssertEqual(factory.defaultValueHistogramBuckets, defaultBucketsFromOTelSpec)
+        XCTAssertEqual(factory.defaultDurationHistogramBuckets, defaultBucketsFromOTelSpec.map { .milliseconds($0) })
+    }
+}


### PR DESCRIPTION
## Motivation

As part of the effort to provide an OLTP backend for Swift Metrics (see #84), we need to provide a Swift Metrics backend. This PR follows on from #85, which added the stateful storage, and provides a factory type that conforms to the Swift Metrics `protocol MetricsFactory`.

## Modifications

- Add dependency on `swift-metrics`.
- Add `OTLPMetricsFactory`, which implements `protocol MetricsFactory` from Swift Metrics, and shims to `OTelMetricRegistry`. 
- Factor out some private test helpers from `OTelTests/MetricStore` to `OTelTesting` for use in `OTelTests/SwiftMetricsFactory`.
- Mark all the possibly-public metrics types as SPI for now.
- Fix a bug in the registry, which wasn't retaining newly created metrics on all code paths, and added a test.
- Unit tests.

## Result

Users can bootstrap the `MetricsSystem` with `OTLPMetricsFactory` so that recorded metrics will be stored in the provided `OTelMetricRegistry`.

Right now, the state for these metrics will just be in memory; the wiring up of the periodic read, conversion, and export using OTLP/gRPC will be in a parallel PR.