### PR TITLE
Update HTTP server example with metrics middleware

### DIFF
--- a/Examples/Server/Package.swift
+++ b/Examples/Server/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
     dependencies: [
         .package(name: "swift-otel", path: "../.."),
         .package(url: "https://github.com/hummingbird-project/hummingbird", exact: "2.0.0-alpha.1"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(
@@ -18,6 +21,9 @@ let package = Package(
                 .product(name: "OTel", package: "swift-otel"),
                 .product(name: "OTLPGRPC", package: "swift-otel"),
                 .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
             ]
         ),
     ]

--- a/Examples/Server/README.md
+++ b/Examples/Server/README.md
@@ -17,20 +17,22 @@ containers to collect and visualize the traces from the server, which is
 running on your local machine.
 
 ```none
-┌─────────────────────────────────────────────────────────────────────┐
-│                                                                 Host│
-│                       ┌────────────────────────────────────────────┐│
-│                       │                              Docker Compose││
-│ ┌────────┐            │ ┌───────────┐                              ││
-│ │        │            │ │           │               ┌────────────┐ ││
-│ │  HTTP  │            │ │   OTel    │               │            │ ││
-│ │ server │─OTLP/gRPC──┼▶│ Collector │─OTLP/gRPC────▶│   Jaeger   │ ││
-│ │        │            │ │           │               │            │ ││
-│ └────────┘            │ └───────────┘               └────────────┘ ││
-│      ▲       ┌──────┐ └────────────────────────────────────────────┘│
-│      └───────│ curl │                                               │
-│   GET /hello └──────┘                                               │
-└─────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│                                                                  Host│
+│                       ┌────────────────────────────────────────────┐ │
+│                       │                              Docker Compose│ │
+│                       │ ┌───────────┐                              │ │
+│                       │ │           │  OTLP/gRPC    ┌────────────┐ │ │
+│ ┌────────┐            │ │           │──────────────▶│   Jaeger   │ │ │
+│ │        │            │ │           │               └────────────┘ │ │
+│ │  HTTP  │ OTLP/gRPC  │ │   OTel    │ GET /metrics  ┌────────────┐ │ │
+│ │ server │────────────┼▶│ Collector │◀──────────────│ Prometheus │ │ │
+│ │        │            │ │           │               └────────────┘ │ │
+│ └────────┘            │ │           │  Debug logs   ┌────────────┐ │ │
+│      ▲      ┌──────┐  │ │           │──────────────▶│   stderr   │ │ │
+│      └──────│ curl │  │ └───────────┘               └────────────┘ │ │
+│  GET /hello └──────┘  └────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
 The server sends requests to OTel Collector, which is configured with an OTLP
@@ -43,8 +45,9 @@ In one terminal window, run the following command:
 
 ```console
 % docker compose -f docker/docker-compose.yaml up
-[+] Running 2/2
+[+] Running 3/3
  ✔ Container docker-jaeger-1          Created                       0.5s
+ ✔ Container docker-prometheus-1      Created                       0.4s
  ✔ Container docker-otel-collector-1  Created                       0.5s
 ...
 ```
@@ -86,3 +89,12 @@ See the traces for the recent requests and click to select a trace for a given r
 
 Click to expand the trace, the metadata associated with the request and the
 process, and the events.
+
+### Visualizing the metrics using Prometheus UI
+
+Now open the Prometheus UI in your web browser by visiting
+[localhost:9090](http://localhost:9090). Click the graph tab and update the
+query to `hb_request_duration_bucket`, or use [this pre-canned
+link](http://localhost:9090/graph?g0.expr=hb_request_duration_bucket).
+
+You should see the graph showing the recent request durations.

--- a/Examples/Server/docker/docker-compose.yaml
+++ b/Examples/Server/docker/docker-compose.yaml
@@ -8,6 +8,20 @@ services:
     ports:
       - "4317:4317"  # OTLP gRPC receiver
 
+  prometheus:
+    image: prom/prometheus:latest
+    entrypoint:
+      - "/bin/prometheus"
+      - "--log.level=debug"
+      - "--config.file=/etc/prometheus/prometheus.yaml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yaml
+    ports:
+      - "9090:9090"  # Prometheus web UI
+
   jaeger:
     image: jaegertracing/all-in-one
     ports:

--- a/Examples/Server/docker/otel-collector-config.yaml
+++ b/Examples/Server/docker/otel-collector-config.yaml
@@ -8,6 +8,9 @@ exporters:
   debug:  # Data sources: traces, metrics, logs
     verbosity: detailed
 
+  prometheus:  # Data sources: metrics
+    endpoint: "otel-collector:7070"
+
   otlp/jaeger:  # Data sources: traces
     endpoint: "jaeger:4317"
     tls:
@@ -15,6 +18,10 @@ exporters:
 
 service:
   pipelines:
+    metrics:
+      receivers: [otlp]
+      # processors: [batch]
+      exporters: [prometheus, debug]
     traces:
       receivers: [otlp]
       exporters: [otlp/jaeger, debug]

--- a/Examples/Server/docker/prometheus.yaml
+++ b/Examples/Server/docker/prometheus.yaml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: "otel-collector"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["otel-collector:7070"]
+
+# yaml-language-server: $schema=http://json.schemastore.org/prometheus


### PR DESCRIPTION
## Motivation

As part of the effort to provide an OLTP backend for Swift Metrics (see #84), we want to show how it can be used in practice. This PR extends the existing HTTP server example, which uses Hummingbird's middleware for tracing and logging, with a metrics middleware.

## Modifications

- Bootstrap the `MetricsSystem` in the HTTP server example with the backend provided by this package.
- Add an `HBMetricsMiddleware` to the HTTP server.
- Update the Docker Compose app with a Prometheus container.
- Update the OTel Collector config in the Docker Compose app, with a metrics pipeline and Prometheus exporter.
- Update the documentation showing how to run the example and visualise the metrics.

## Result

The example HTTP server package shows how to bootstrap all three Swift observability backends and how to integrate with observability tooling.