### PR TITLE
Remove import of XCTest from OTel source

### DIFF
--- a/Sources/OTel/Helpers/HookedFatalError.swift
+++ b/Sources/OTel/Helpers/HookedFatalError.swift
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct NIOConcurrencyHelpers.NIOLockedValueBox
 import class Foundation.Thread
+import struct NIOConcurrencyHelpers.NIOLockedValueBox
 
 func fatalError(_ message: @autoclosure () -> String = String(), file: StaticString = #file, line: UInt = #line) -> Never {
     print("hooking fatal error")

--- a/Sources/OTel/Helpers/HookedFatalError.swift
+++ b/Sources/OTel/Helpers/HookedFatalError.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import struct NIOConcurrencyHelpers.NIOLockedValueBox
-import XCTest
+import class Foundation.Thread
 
 func fatalError(_ message: @autoclosure () -> String = String(), file: StaticString = #file, line: UInt = #line) -> Never {
     print("hooking fatal error")


### PR DESCRIPTION
## Motivation

We added the ability to hook `fatalError` for testing recently, but left an unnecessary import of `XCTest` in the sources of the `OTel` module. This isn't needed, the additional XCTest helpers are (and should be) in `OTelTesting`.

## Modifications

- Remove `import XCTest` from `HookedFatalError.swift`.

## Result

Users depending on `OTel` shouldn't see an XCTest import.

## Related

- Fixed #91.