### PR TITLE
Add OTelMetricExporter protocol and noop, console, and multiplex exporters

### DIFF
--- a/Sources/OTel/Metrics/OTelMetricExporter/OTelConsoleMetricExporter.swift
+++ b/Sources/OTel/Metrics/OTelMetricExporter/OTelConsoleMetricExporter.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A metric exporter that logs metrics to the console for debugging.
+@_spi(Metrics)
+public struct OTelConsoleMetricExporter: OTelMetricExporter {
+    /// Create a new ``OTelConsoleMetricExporter``.
+    init() {}
+
+    public func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
+        for metric in batch {
+            print(metric)
+        }
+    }
+
+    public func forceFlush() async throws {}
+
+    public func shutdown() async {}
+}

--- a/Sources/OTel/Metrics/OTelMetricExporter/OTelMetricExporter.swift
+++ b/Sources/OTel/Metrics/OTelMetricExporter/OTelMetricExporter.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2023 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Exports a batch of metrics.
+///
+/// - Seealso: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/metrics/sdk.md#metricexporter
+@_spi(Metrics)
+public protocol OTelMetricExporter: Sendable {
+    /// Export the given batch of metrics.
+    ///
+    /// - Parameter batch: A batch of metrics to export.
+    func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws
+
+    /// Force the exporter to export any previously received metrics as soon as possible.
+    func forceFlush() async throws
+
+    /// Shut down the exporter.
+    ///
+    /// This method gives exporters a chance to wrap up existing work such as finishing in-flight exports while not allowing new ones anymore.
+    /// Once this method returns, the exporter is to be considered shut down and further invocations of ``export(_:)``
+    /// are expected to fail.
+    func shutdown() async
+}
+
+/// An error indicating that an exporter has already been shut down but has been asked to export a batch of metrics.
+@_spi(Metrics)
+public struct OTelMetricExporterAlreadyShutDownError: Error {
+    public init() {}
+}

--- a/Sources/OTel/Metrics/OTelMetricExporter/OTelMultiplexMetricExporter.swift
+++ b/Sources/OTel/Metrics/OTelMetricExporter/OTelMultiplexMetricExporter.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A metric exporter that delegates to multiple other exports.
+@_spi(Metrics)
+public struct OTelMultiplexMetricExporter: OTelMetricExporter {
+    private let exporters: [any OTelMetricExporter]
+
+    /// Initialize an ``OTelMultiplexMetricExporter``.
+    ///
+    /// - Parameter exporters: An array of ``OTelMetricExporter``s, each of which will receive the batches to export.
+    public init(exporters: [any OTelMetricExporter]) {
+        self.exporters = exporters
+    }
+
+    public func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for exporter in exporters {
+                group.addTask { try await exporter.export(batch) }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    public func forceFlush() async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for exporter in exporters {
+                group.addTask { try await exporter.forceFlush() }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    public func shutdown() async {
+        await withTaskGroup(of: Void.self) { group in
+            for exporter in exporters {
+                group.addTask { await exporter.shutdown() }
+            }
+            await group.waitForAll()
+        }
+    }
+}

--- a/Sources/OTel/Metrics/OTelMetricExporter/OTelNoOpMetricExporter.swift
+++ b/Sources/OTel/Metrics/OTelMetricExporter/OTelNoOpMetricExporter.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2023 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A metric exporter that ignores all operations, used when no metrics should be exported.
+///
+/// - TODO: Why are we providing this?
+@_spi(Metrics)
+public struct OTelNoOpMetricExporter: OTelMetricExporter {
+    public init() {}
+    public func export(_ batch: some Collection<OTelResourceMetrics>) async throws {}
+    public func forceFlush() async throws {}
+    public func shutdown() async {}
+}

--- a/Sources/OTelTesting/RecordingMetricExporter.swift
+++ b/Sources/OTelTesting/RecordingMetricExporter.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOConcurrencyHelpers
+@_spi(Metrics) import OTel
+import XCTest
+
+package struct RecordingMetricExporter: OTelMetricExporter {
+    package typealias ExportCall = Collection<OTel.OTelResourceMetrics> & Sendable
+
+    package struct RecordedCalls {
+        var exportCalls = [any ExportCall]()
+        var forceFlushCallCount = 0
+        var shutdownCallCount = 0
+    }
+
+    package let recordedCalls = NIOLockedValueBox(RecordedCalls())
+
+    package init() {}
+
+    package func export(_ batch: some Collection<OTel.OTelResourceMetrics> & Sendable) {
+        recordedCalls.withLockedValue { $0.exportCalls.append(batch) }
+    }
+
+    package func forceFlush() {
+        recordedCalls.withLockedValue { $0.forceFlushCallCount += 1 }
+    }
+
+    package func shutdown() {
+        recordedCalls.withLockedValue { $0.shutdownCallCount += 1 }
+    }
+}
+
+extension RecordingMetricExporter {
+    package func assert(
+        exportCallCount: Int,
+        forceFlushCallCount: Int,
+        shutdownCallCount: Int,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let recordedCalls = recordedCalls.withLockedValue { $0 }
+        XCTAssertEqual(recordedCalls.exportCalls.count, exportCallCount, "Unexpected export call count", file: file, line: line)
+        XCTAssertEqual(recordedCalls.forceFlushCallCount, forceFlushCallCount, "Unexpected forceFlush call count", file: file, line: line)
+        XCTAssertEqual(recordedCalls.shutdownCallCount, shutdownCallCount, "Unexpected shutdown call count", file: file, line: line)
+    }
+}

--- a/Tests/OTelTests/Metrics/OTelMetricExporter/OTelMetricExporterTests.swift
+++ b/Tests/OTelTests/Metrics/OTelMetricExporter/OTelMetricExporterTests.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable @_spi(Metrics) import OTel
+@_spi(Metrics) import OTelTesting
+import XCTest
+
+final class OTelMetricExporterTests: XCTestCase {
+    func test_MultiplexExporter_forwadsCallsToAllExporters() async throws {
+        let recordingExporters = (1 ... 3).map { _ in RecordingMetricExporter() }
+        let multiplexExporter = OTelMultiplexMetricExporter(
+            exporters: recordingExporters + [OTelNoOpMetricExporter(), OTelConsoleMetricExporter()]
+        )
+
+        recordingExporters.forEach { $0.assert(exportCallCount: 0, forceFlushCallCount: 0, shutdownCallCount: 0) }
+
+        try await multiplexExporter.export([])
+        try await multiplexExporter.export([OTelResourceMetrics(scopeMetrics: [])])
+        recordingExporters.forEach { $0.assert(exportCallCount: 2, forceFlushCallCount: 0, shutdownCallCount: 0) }
+
+        try await multiplexExporter.forceFlush()
+        recordingExporters.forEach { $0.assert(exportCallCount: 2, forceFlushCallCount: 1, shutdownCallCount: 0) }
+
+        await multiplexExporter.shutdown()
+        recordingExporters.forEach { $0.assert(exportCallCount: 2, forceFlushCallCount: 1, shutdownCallCount: 1) }
+    }
+}


### PR DESCRIPTION
## Motivation

As part of the effort to provide an OLTP backend for Swift Metrics (see #84), we need some way to export the in-memory metrics state. This PR follows on from #89, which added the subset of the OTLP datamodel we are targeting, and provides an exporter protocol, some simple exporters (not OTLP/gRPC yet), and a multiplex convenience.

At this point, we are starting to transition more into the kinds of types spelled out in the OTel specification, which defines the names and functions for the exporter.

## Modifications

- Add `protocol OTelMetricExporter`.
- Add `OTelNoOpMetricExporter`.
- Add `OTelConsoleMetricExporter`.
- Add `OTelMultiplexMetricExporter`.
- Add `OTelRecordingMetricExporter` to `OTelTesting`.
- Unit tests.

## Results

There's a defined interface for exporting in-memory metrics produced by an `OTelMetricProducer`.

This paves the way for _readers_, which tie _producers_ to _exporters_, which will be coming up in a subsequent PR.