### PR TITLE
Add OTelPeriodicExportingMetricsReader and configuration

### DIFF
--- a/Sources/OTel/Helpers/Timeout.swift
+++ b/Sources/OTel/Helpers/Timeout.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package func withTimeout<ClockType: Clock, ChildTaskResult>(
+    _ timeout: ClockType.Duration,
+    priority: TaskPriority? = nil,
+    clock: ClockType,
+    operation: @escaping @Sendable () async throws -> ChildTaskResult
+) async rethrows -> ChildTaskResult where ChildTaskResult: Sendable {
+    try await withThrowingTaskGroup(of: ChildTaskResult.self) { group in
+        group.addTask(priority: priority) {
+            try await clock.sleep(for: timeout)
+            throw CancellationError()
+        }
+        group.addTask(priority: priority, operation: operation)
+        let result = try await group.next()!
+        group.cancelAll()
+        return result
+    }
+}
+
+package func withTimeout<ChildTaskResult>(
+    _ timeout: Duration,
+    priority: TaskPriority? = nil,
+    operation: @escaping @Sendable () async throws -> ChildTaskResult
+) async rethrows -> ChildTaskResult where ChildTaskResult: Sendable {
+    try await withTimeout(timeout, priority: priority, clock: ContinuousClock(), operation: operation)
+}

--- a/Sources/OTel/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
+++ b/Sources/OTel/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AsyncAlgorithms
+import Logging
+import ServiceLifecycle
+
+@_spi(Metrics)
+public struct OTelPeriodicExportingMetricsReader<Clock: _Concurrency.Clock>: Service, CustomStringConvertible where Clock.Duration == Duration {
+    public let description = "OTelPeriodicExportingMetricsReader"
+
+    private let logger = Logger(label: "OTelPeriodicExportingMetricsReader")
+
+    var resource: OTelResource
+    var producer: OTelMetricProducer // TODO: support for multiple producers?
+    var exporter: OTelMetricExporter
+    var configuration: OTelPeriodicExportingMetricsReaderConfiguration
+    var clock: Clock
+
+    init(
+        resource: OTelResource,
+        producer: OTelMetricProducer,
+        exporter: OTelMetricExporter,
+        configuration: OTelPeriodicExportingMetricsReaderConfiguration,
+        clock: Clock
+    ) {
+        self.resource = resource
+        self.producer = producer
+        self.exporter = exporter
+        self.configuration = configuration
+        self.clock = clock
+    }
+
+    func tick() async {
+        logger.trace("Reading metrics from producer.")
+        let metrics = producer.produce()
+        let batch = [
+            OTelResourceMetrics(
+                resource: resource,
+                scopeMetrics: [OTelScopeMetrics(
+                    scope: .init(name: "swift-otel", version: OTelLibrary.version, attributes: [], droppedAttributeCount: 0),
+                    metrics: metrics
+                )]
+            ),
+        ]
+        logger.debug("Exporting metrics.", metadata: ["count": "\(metrics.count)"])
+        do {
+            try await withTimeout(configuration.exportTimeout, clock: clock) {
+                try await exporter.export(batch)
+            }
+        } catch is CancellationError {
+            logger.warning("Timed out exporting metrics.", metadata: ["timeout": "\(configuration.exportTimeout)"])
+        } catch {
+            logger.error("Failed to export metrics.", metadata: ["error": "\(error)"])
+        }
+    }
+
+    public func run() async throws {
+        let interval = configuration.exportInterval
+        logger.info("Started periodic loop.", metadata: ["interval": "\(interval)"])
+        for try await _ in AsyncTimerSequence.repeating(every: interval, clock: clock).cancelOnGracefulShutdown() {
+            logger.trace("Timer fired.", metadata: ["interval": "\(interval)"])
+            await tick()
+        }
+    }
+}
+
+@_spi(Metrics)
+extension OTelPeriodicExportingMetricsReader where Clock == ContinuousClock {
+    public init(
+        resource: OTelResource,
+        producer: OTelMetricProducer,
+        exporter: OTelMetricExporter,
+        configuration: OTelPeriodicExportingMetricsReaderConfiguration
+    ) {
+        self.resource = resource
+        self.producer = producer
+        self.exporter = exporter
+        self.configuration = configuration
+        clock = .continuous
+    }
+}

--- a/Sources/OTel/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderConfiguration.swift
+++ b/Sources/OTel/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderConfiguration.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// The configuration options for an ``OTelPeriodicExportingMetricsReader``.
+@_spi(Metrics)
+public struct OTelPeriodicExportingMetricsReaderConfiguration: Sendable {
+    /// The time interval between the start of two export attempts.
+    public var exportInterval: Duration
+
+    /// The maximum allowed time to export data.
+    public var exportTimeout: Duration
+
+    /// Create a configuration for a periodic metrics reader.
+    ///
+    /// - Parameters:
+    ///   - environment: The environment variables.
+    ///   - exportInterval: The time interval between the start of two export attempts.
+    ///     Defaults to the value of `OTEL_METRIC_EXPORT_INTERVAL`, or 60 seconds, if the environment variable is unset.
+    ///   - exportTimeout: The maximum allowed time to export data.
+    ///     Defaults to the value of `OTEL_METRIC_EXPORT_TIMEOUT`, or 30 seconds, if the environment variable is unset.
+    public init(
+        environment: OTelEnvironment,
+        exportInterval: Duration? = nil,
+        exportTimeout: Duration? = nil
+    ) {
+        self.exportInterval = environment.requiredValue(
+            programmaticOverride: exportInterval,
+            key: "OTEL_METRIC_EXPORT_INTERVAL",
+            defaultValue: .seconds(60),
+            transformValue: {
+                guard let milliseconds = UInt($0) else { return nil }
+                return Duration.milliseconds(milliseconds)
+            }
+        )
+        self.exportTimeout = environment.requiredValue(
+            programmaticOverride: exportTimeout,
+            key: "OTEL_METRIC_EXPORT_TIMEOUT",
+            defaultValue: .seconds(30),
+            transformValue: {
+                guard let milliseconds = UInt($0) else { return nil }
+                return Duration.milliseconds(milliseconds)
+            }
+        )
+    }
+}

--- a/Sources/OTelTesting/RecordingLogHandler.swift
+++ b/Sources/OTelTesting/RecordingLogHandler.swift
@@ -18,11 +18,15 @@ package struct RecordingLogHandler: LogHandler {
     package typealias LogFunctionCall = (level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?)
 
     package let recordedLogMessages = NIOLockedValueBox([LogFunctionCall]())
+    package let (recordedLogMessageStream, recordedLogMessageContinuation) = AsyncStream.makeStream(of: LogFunctionCall.self)
+    package let counts = NIOLockedValueBox([Logger.Level: Int]())
 
     package init() {}
 
     package func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
         recordedLogMessages.withLockedValue { $0.append((level, message, metadata)) }
+        counts.withLockedValue { $0[level] = $0[level, default: 0] + 1 }
+        recordedLogMessageContinuation.yield((level, message, metadata))
     }
 
     package var metadata: Logging.Logger.Metadata {
@@ -38,5 +42,15 @@ package struct RecordingLogHandler: LogHandler {
     package subscript(metadataKey _: String) -> Logging.Logger.Metadata.Value? {
         get { fatalError("unimplemented") }
         set(newValue) { fatalError("unimplemented") }
+    }
+}
+
+extension RecordingLogHandler {
+    package var warningCount: Int {
+        counts.withLockedValue { $0[.warning, default: 0] }
+    }
+
+    package var errorCount: Int {
+        counts.withLockedValue { $0[.error, default: 0] }
     }
 }

--- a/Tests/OTelTests/Helpers/TimeoutTests.swift
+++ b/Tests/OTelTests/Helpers/TimeoutTests.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import XCTest
+
+final class TimeoutTests: XCTestCase {
+    func test_withTimeout_operationCompletesWithinTime_returnsResult() async throws {
+        let expectation = expectation(description: "cancellation handler not called")
+        expectation.isInverted = true
+        let result = try? await withTimeout(.milliseconds(1)) {
+            try await withTaskCancellationHandler {
+                try await Task.sleep(for: .nanoseconds(1))
+                return 42
+            } onCancel: {
+                expectation.fulfill()
+            }
+        }
+        XCTAssertEqual(result, 42)
+        await fulfillment(of: [expectation], timeout: 0)
+    }
+
+    func test_withTimeout_operationDoesNotCompletesWithinTime_throwsCancellationError() async throws {
+        let expectation = expectation(description: "cancellation handler called")
+        let result = try? await withTimeout(.nanoseconds(1)) {
+            try await withTaskCancellationHandler {
+                try await Task.sleep(for: .milliseconds(1))
+                return 42
+            } onCancel: {
+                expectation.fulfill()
+            }
+        }
+        XCTAssertEqual(result, nil)
+        await fulfillment(of: [expectation], timeout: 0)
+    }
+
+    func test_withTimeout_operationThrowsError_throwsError() async throws {
+        let expectation = expectation(description: "cancellation handler not called")
+        expectation.isInverted = true
+        @Sendable func alwaysThrows() throws -> Int {
+            struct SomeError: Error {}
+            throw SomeError()
+        }
+        let result = try? await withTimeout(.milliseconds(1)) {
+            try await withTaskCancellationHandler {
+                try await Task.sleep(for: .nanoseconds(1))
+                return try alwaysThrows()
+            } onCancel: {
+                expectation.fulfill()
+            }
+        }
+        XCTAssertEqual(result, nil)
+        await fulfillment(of: [expectation], timeout: 0)
+    }
+}

--- a/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Logging
+@testable import Logging
 import struct NIOConcurrencyHelpers.NIOLockedValueBox
 @testable @_spi(Metrics) import OTel
 import OTelTesting
@@ -387,15 +387,14 @@ final class OTelMetricRegistryTests: XCTestCase {
 final class DuplicateRegistrationHandlerTests: XCTestCase {
     func test_LoggingDuplicateRegistrationHandler() {
         let recordingLogHandler = RecordingLogHandler()
-        LoggingSystem.bootstrap { _ in recordingLogHandler }
+        LoggingSystem.bootstrapInternal { _ in recordingLogHandler }
         let handler = WarningDuplicateRegistrationHandler(logger: Logger(label: "test"))
         handler.handle(
             newRegistration: .counter(name: "name"),
             existingRegistrations: [.gauge(name: "name"), .histogram(name: "name")]
         )
         let recordedLogMessages = recordingLogHandler.recordedLogMessages.withLockedValue { $0 }
-        XCTAssertEqual(recordedLogMessages.count, 1)
-        XCTAssertEqual(recordedLogMessages.first?.level, .warning)
+        XCTAssertEqual(recordingLogHandler.warningCount, 1)
     }
 
     func test_FatalErrorDuplicateRegistrationHandler() {

--- a/Tests/OTelTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderConfigurationTests.swift
+++ b/Tests/OTelTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderConfigurationTests.swift
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOConcurrencyHelpers
+@testable @_spi(Metrics) import OTel
+@testable @_spi(Metrics) import OTelTesting
+import XCTest
+
+final class OTelPeriodicExportingMetricsReaderConfigurationTests: XCTestCase {
+    func test_exportInterval_withProgrammaticOverride_usesProgrammaticOverride() {
+        let configuration = OTelPeriodicExportingMetricsReaderConfiguration(
+            environment: OTelEnvironment(values: [:]),
+            exportInterval: .seconds(42)
+        )
+        XCTAssertEqual(configuration.exportInterval, .seconds(42))
+    }
+
+    func test_exportInterval_withEnvironmentValue_usesEnvironmentValue() {
+        let configuration = OTelPeriodicExportingMetricsReaderConfiguration(
+            environment: OTelEnvironment(values: ["OTEL_METRIC_EXPORT_INTERVAL": "42000"]),
+            exportInterval: nil
+        )
+        XCTAssertEqual(configuration.exportInterval, .seconds(42))
+    }
+
+    func test_exportInterval_withProgrammaticOverrideAndEnvironmentValue_usesProgrammaticOverride() {
+        let configuration = OTelPeriodicExportingMetricsReaderConfiguration(
+            environment: OTelEnvironment(values: ["OTEL_METRIC_EXPORT_INTERVAL": "42000"]),
+            exportInterval: .seconds(84)
+        )
+        XCTAssertEqual(configuration.exportInterval, .seconds(84))
+    }
+
+    func test_exportInterval_withoutConfiguration_usesDefaultValue() {
+        let configuration = OTelPeriodicExportingMetricsReaderConfiguration(
+            environment: OTelEnvironment(values: [:])
+        )
+        XCTAssertEqual(configuration.exportInterval, .seconds(60))
+    }
+
+    func test_exportInterval_invalidEnvironmentVariable_throwsFatalError() {
+        XCTAssertThrowsFatalError {
+            _ = OTelPeriodicExportingMetricsReaderConfiguration(
+                environment: OTelEnvironment(values: ["OTEL_METRIC_EXPORT_INTERVAL": "badger"])
+            )
+        }
+    }
+
+    func test_exportTimeout_withProgrammaticOverride_usesProgrammaticOverride() {
+        let configuration = OTelPeriodicExportingMetricsReaderConfiguration(
+            environment: OTelEnvironment(values: [:]),
+            exportTimeout: .seconds(42)
+        )
+        XCTAssertEqual(configuration.exportTimeout, .seconds(42))
+    }
+
+    func test_exportTimeout_withEnvironmentValue_usesEnvironmentValue() {
+        let configuration = OTelPeriodicExportingMetricsReaderConfiguration(
+            environment: OTelEnvironment(values: ["OTEL_METRIC_EXPORT_TIMEOUT": "42000"]),
+            exportTimeout: nil
+        )
+        XCTAssertEqual(configuration.exportTimeout, .seconds(42))
+    }
+
+    func test_exportTimeout_withProgrammaticOverrideAndEnvironmentValue_usesProgrammaticOverride() {
+        let configuration = OTelPeriodicExportingMetricsReaderConfiguration(
+            environment: OTelEnvironment(values: ["OTEL_METRIC_EXPORT_TIMEOUT": "42000"]),
+            exportTimeout: .seconds(84)
+        )
+        XCTAssertEqual(configuration.exportTimeout, .seconds(84))
+    }
+
+    func test_exportTimeout_withoutConfiguration_usesDefaultValue() {
+        let configuration = OTelPeriodicExportingMetricsReaderConfiguration(
+            environment: OTelEnvironment(values: [:])
+        )
+        XCTAssertEqual(configuration.exportTimeout, .seconds(30))
+    }
+
+    func test_exportTimeout_invalidEnvironmentVariable_throwsFatalError() {
+        XCTAssertThrowsFatalError {
+            _ = OTelPeriodicExportingMetricsReaderConfiguration(
+                environment: OTelEnvironment(values: ["OTEL_METRIC_EXPORT_TIMEOUT": "badger"])
+            )
+        }
+    }
+}

--- a/Tests/OTelTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
+++ b/Tests/OTelTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
@@ -1,0 +1,271 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import Logging
+import NIOConcurrencyHelpers
+@testable @_spi(Metrics) import OTel
+@testable @_spi(Metrics) import OTelTesting
+import XCTest
+
+final class OTelPeriodicExportingMetricsReaderTests: XCTestCase {
+    func test_normalBehavior_periodicallyExports() async throws {
+        let clock = TestClock()
+        let exporter = RecordingMetricExporter()
+        let producer = MockMetricProducer()
+        let reader = OTelPeriodicExportingMetricsReader(
+            resource: .init(),
+            producer: producer,
+            exporter: exporter,
+            configuration: .init(
+                environment: .detected(),
+                exportInterval: .seconds(1),
+                exportTimeout: .milliseconds(100)
+            ),
+            clock: clock
+        )
+        var sleepCalls = clock.sleepCalls.makeAsyncIterator()
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await reader.run()
+            }
+
+            // await sleep for tick.
+            await sleepCalls.next()
+
+            // while the timer sequence is sleeping, check the expected producer and exporter counts.
+            producer.assert(produceCallCount: 0)
+            exporter.assert(exportCallCount: 0, forceFlushCallCount: 0, shutdownCallCount: 0)
+
+            // advance the clock for the tick.
+            clock.advance(to: .seconds(1))
+
+            // await sleep for export timeout and advance passed it.
+            await sleepCalls.next()
+            clock.advance(by: .milliseconds(200))
+
+            // await sleep for tick.
+            await sleepCalls.next()
+
+            // while the timer sequence is sleeping, check the expected producer and exporter counts.
+            producer.assert(produceCallCount: 1)
+            exporter.assert(exportCallCount: 1, forceFlushCallCount: 0, shutdownCallCount: 0)
+
+            // advance the clock for the tick.
+            clock.advance(to: .seconds(2))
+
+            // await sleep for export timeout and advance passed it.
+            await sleepCalls.next()
+            clock.advance(by: .milliseconds(200))
+
+            // await sleep for tick.
+            await sleepCalls.next()
+
+            // while the timer sequence is sleeping, check the expected producer and exporter counts.
+            producer.assert(produceCallCount: 2)
+            exporter.assert(exportCallCount: 2, forceFlushCallCount: 0, shutdownCallCount: 0)
+
+            group.cancelAll()
+        }
+    }
+
+    func test_exportTakesLongerThanTimeout_logsWarning() async throws {
+        let recordingLogHandler = RecordingLogHandler()
+        LoggingSystem.bootstrapInternal { _ in recordingLogHandler }
+        let clock = TestClock()
+        let exporter = MockMetricExporter(behavior: .sleep)
+        let producer = MockMetricProducer()
+        let reader = OTelPeriodicExportingMetricsReader(
+            resource: .init(),
+            producer: producer,
+            exporter: exporter,
+            configuration: .init(
+                environment: .detected(),
+                exportInterval: .seconds(1),
+                exportTimeout: .milliseconds(100)
+            ),
+            clock: clock
+        )
+        var sleepCalls = clock.sleepCalls.makeAsyncIterator()
+        var warningLogs = recordingLogHandler.recordedLogMessageStream.filter { $0.level == .warning }.makeAsyncIterator()
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await reader.run()
+            }
+
+            // await sleep for tick.
+            await sleepCalls.next()
+
+            // while the timer sequence is sleeping, check the export cancellation and warning log counts.
+            XCTAssertEqual(recordingLogHandler.warningCount, 0)
+            XCTAssertEqual(exporter.cancellationCount.withLockedValue { $0 }, 0)
+
+            // advance the clock for the tick.
+            clock.advance(to: .seconds(1))
+
+            // await sleep for export timeout and advance passed it.
+            await sleepCalls.next()
+            clock.advance(by: .milliseconds(200))
+            _ = await warningLogs.next()
+
+            // await sleep for tick.
+            await sleepCalls.next()
+
+            // while the timer sequence is sleeping, check the export cancellation and warning log counts.
+            XCTAssertEqual(recordingLogHandler.warningCount, 1)
+            XCTAssertEqual(exporter.cancellationCount.withLockedValue { $0 }, 1)
+
+            // advance the clock for the tick.
+            clock.advance(to: .seconds(2))
+
+            // await sleep for export timeout and advance passed it.
+            await sleepCalls.next()
+            clock.advance(by: .milliseconds(200))
+            _ = await warningLogs.next()
+
+            // await sleep for tick.
+            await sleepCalls.next()
+
+            // while the timer sequence is sleeping, check the export cancellation and warning log counts.
+            XCTAssertEqual(recordingLogHandler.warningCount, 2)
+            XCTAssertEqual(exporter.cancellationCount.withLockedValue { $0 }, 2)
+
+            group.cancelAll()
+        }
+    }
+
+    func test_exportThrowsError_logsError() async throws {
+        let recordingLogHandler = RecordingLogHandler()
+        LoggingSystem.bootstrapInternal { _ in recordingLogHandler }
+        let clock = TestClock()
+        let exporter = MockMetricExporter(behavior: .throw)
+        let producer = MockMetricProducer()
+        let reader = OTelPeriodicExportingMetricsReader(
+            resource: .init(),
+            producer: producer,
+            exporter: exporter,
+            configuration: .init(
+                environment: .detected(),
+                exportInterval: .seconds(1),
+                exportTimeout: .milliseconds(100)
+            ),
+            clock: clock
+        )
+        var sleepCalls = clock.sleepCalls.makeAsyncIterator()
+        var errorLogs = recordingLogHandler.recordedLogMessageStream.filter { $0.level == .error }.makeAsyncIterator()
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await reader.run()
+            }
+
+            // await sleep for tick.
+            await sleepCalls.next()
+
+            // while the timer sequence is sleeping, check the export throw and error log counts.
+            XCTAssertEqual(recordingLogHandler.errorCount, 0)
+            XCTAssertEqual(exporter.throwCount.withLockedValue { $0 }, 0)
+
+            // advance the clock for the tick.
+            clock.advance(to: .seconds(1))
+
+            // await sleep for export timeout.
+            await sleepCalls.next()
+            _ = await errorLogs.next()
+
+            // await sleep for tick.
+            await sleepCalls.next()
+
+            // while the timer sequence is sleeping, check the export cancellation and error log counts.
+            XCTAssertEqual(recordingLogHandler.errorCount, 1)
+            XCTAssertEqual(exporter.throwCount.withLockedValue { $0 }, 1)
+
+            // advance the clock for the tick.
+            clock.advance(to: .seconds(2))
+
+            // await sleep for export timeout and advance passed it.
+            await sleepCalls.next()
+            _ = await errorLogs.next()
+
+            // await sleep for tick.
+            await sleepCalls.next()
+
+            // while the timer sequence is sleeping, check the export cancellation and error log counts.
+            XCTAssertEqual(recordingLogHandler.errorCount, 2)
+            XCTAssertEqual(exporter.throwCount.withLockedValue { $0 }, 2)
+
+            group.cancelAll()
+        }
+    }
+
+    func test_initalizer_usesContinuousClockByDefault() {
+        let reader = OTelPeriodicExportingMetricsReader(
+            resource: .init(),
+            producer: MockMetricProducer(),
+            exporter: RecordingMetricExporter(),
+            configuration: .init(environment: .detected())
+        )
+        XCTAssert(type(of: reader.clock) == ContinuousClock.self)
+    }
+}
+
+// MARK: - Helpers
+
+final class MockMetricProducer: Sendable, OTelMetricProducer {
+    let produceReturnValue = NIOLockedValueBox([OTelMetricPoint]())
+    let produceCallCount = NIOLockedValueBox(0)
+    func produce() -> [OTelMetricPoint] {
+        produceCallCount.withLockedValue { $0 += 1 }
+        return produceReturnValue.withLockedValue { $0 }
+    }
+
+    func assert(produceCallCount: Int, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(self.produceCallCount.withLockedValue { $0 }, produceCallCount, file: file, line: line)
+    }
+}
+
+final class MockMetricExporter: Sendable, OTelMetricExporter {
+    struct MockError: Error {}
+
+    enum Behavior {
+        case sleep
+        case `throw`
+    }
+
+    let behavior: Behavior
+
+    let cancellationCount = NIOLockedValueBox(0)
+    let throwCount = NIOLockedValueBox(0)
+
+    init(behavior: Behavior) {
+        self.behavior = behavior
+    }
+
+    func export(_ batch: some Collection<OTel.OTelResourceMetrics> & Sendable) async throws {
+        switch behavior {
+        case .sleep:
+            try await withTaskCancellationHandler {
+                while true {
+                    try await Task.sleep(for: .seconds(60))
+                }
+            } onCancel: {
+                cancellationCount.withLockedValue { $0 += 1 }
+            }
+        case .throw:
+            throwCount.withLockedValue { $0 += 1 }
+            throw MockError()
+        }
+    }
+
+    func forceFlush() async throws { fatalError("not implemented") }
+
+    func shutdown() async { fatalError("not implemented") }
+}


### PR DESCRIPTION
## Motivation

As part of the effort to provide an OLTP backend for Swift Metrics (see #84), we need a periodic reader that exports metrics. This PR follows on from #89 and #94, which defined `protocol OTelMetricProducer` and `protocol OTelMetricExporter` respectively, and adds the `OTelPeriodicExportingMetricsReader`, a type defined in the OTel specification, which bridges a producer to an exporter.

## Modifications

- Add `OTLPPeriodicExportingMetricsReader`.
- Add `OTLPPeriodicExportingMetricsReaderConfiguration`.
- Add tests.
- Fix deadlocks and data races in `TestClock`.

## Result

Users can create a periodic exporting reader that bridges a metric producer to an exporter. Configuration environment variable names and default values are taken from the OTel spec.