### PR TITLE
Extract unit and description from dimensions provided through Swift Metrics API

### DIFF
--- a/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
+++ b/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
@@ -224,24 +224,6 @@ public final class OTelMetricRegistry: Sendable {
     }
 }
 
-extension OTelMetricRegistry {
-    func makeCounter(name: String, unit: String? = nil, description: String? = nil, labels: [(String, String)]) -> Counter {
-        makeCounter(name: name, unit: unit, description: description, attributes: Set(labels))
-    }
-
-    func makeGauge(name: String, unit: String? = nil, description: String? = nil, labels: [(String, String)]) -> Gauge {
-        makeGauge(name: name, unit: unit, description: description, attributes: Set(labels))
-    }
-
-    func makeDurationHistogram(name: String, unit: String? = nil, description: String? = nil, labels: [(String, String)], buckets: [Duration]) -> DurationHistogram {
-        makeDurationHistogram(name: name, unit: unit, description: description, attributes: Set(labels), buckets: buckets)
-    }
-
-    func makeValueHistogram(name: String, unit: String? = nil, description: String? = nil, labels: [(String, String)], buckets: [Double]) -> ValueHistogram {
-        makeValueHistogram(name: name, unit: unit, description: description, attributes: Set(labels), buckets: buckets)
-    }
-}
-
 struct InstrumentIdentifier: Equatable, Hashable, Sendable {
     var name: String
     var unit: String?

--- a/Sources/OTel/Metrics/OTelInstrument/Counter+OTelInstrument.swift
+++ b/Sources/OTel/Metrics/OTelInstrument/Counter+OTelInstrument.swift
@@ -36,8 +36,8 @@ extension Counter: OTelMetricInstrument {
         }
         return OTelMetricPoint(
             name: name,
-            description: "",
-            unit: "",
+            description: description ?? "",
+            unit: unit ?? "",
             data: .sum(OTelSum(
                 points: [.init(
                     attributes: attributes.map { OTelAttribute(key: $0.key, value: $0.value) },

--- a/Sources/OTel/Metrics/OTelInstrument/Gauge+OTelInstrument.swift
+++ b/Sources/OTel/Metrics/OTelInstrument/Gauge+OTelInstrument.swift
@@ -28,8 +28,8 @@ extension Gauge: OTelMetricInstrument {
         let value = Double(bitPattern: atomic.load(ordering: .relaxed))
         return OTelMetricPoint(
             name: name,
-            description: "",
-            unit: "",
+            description: description ?? "",
+            unit: unit ?? "",
             data: .gauge(OTelGauge(
                 points: [.init(
                     attributes: attributes.map { OTelAttribute(key: $0.key, value: $0.value) },

--- a/Sources/OTel/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
+++ b/Sources/OTel/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
@@ -29,8 +29,8 @@ extension Histogram: OTelMetricInstrument {
         let state = box.withLockedValue { $0 }
         return OTelMetricPoint(
             name: name,
-            description: "",
-            unit: "",
+            description: description ?? "",
+            unit: unit ?? "",
             data: .histogram(OTelHistogram(
                 aggregationTemporality: .cumulative,
                 points: [.init(

--- a/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
@@ -62,40 +62,20 @@ final class OTelMetricRegistryTests: XCTestCase {
     func test_identity_sameNameSameLabels_identical() {
         let registry = OTelMetricRegistry()
         XCTAssertIdentical(
-            registry.makeCounter(name: "c", labels: [("one", "1")]),
-            registry.makeCounter(name: "c", labels: [("one", "1")])
+            registry.makeCounter(name: "c", attributes: Set([("one", "1")])),
+            registry.makeCounter(name: "c", attributes: Set([("one", "1")]))
         )
         XCTAssertIdentical(
-            registry.makeGauge(name: "g", labels: [("one", "1")]),
-            registry.makeGauge(name: "g", labels: [("one", "1")])
+            registry.makeGauge(name: "g", attributes: Set([("one", "1")])),
+            registry.makeGauge(name: "g", attributes: Set([("one", "1")]))
         )
         XCTAssertIdentical(
-            registry.makeDurationHistogram(name: "d", labels: [("one", "1")], buckets: []),
-            registry.makeDurationHistogram(name: "d", labels: [("one", "1")], buckets: [])
+            registry.makeDurationHistogram(name: "d", attributes: Set([("one", "1")]), buckets: []),
+            registry.makeDurationHistogram(name: "d", attributes: Set([("one", "1")]), buckets: [])
         )
         XCTAssertIdentical(
-            registry.makeValueHistogram(name: "v", labels: [("one", "1")], buckets: []),
-            registry.makeValueHistogram(name: "v", labels: [("one", "1")], buckets: [])
-        )
-    }
-
-    func test_identity_sameNameDifferentLabelOrder_identical() {
-        let registry = OTelMetricRegistry()
-        XCTAssertIdentical(
-            registry.makeCounter(name: "c", labels: [("one", "1"), ("two", "2")]),
-            registry.makeCounter(name: "c", labels: [("two", "2"), ("one", "1")])
-        )
-        XCTAssertIdentical(
-            registry.makeGauge(name: "g", labels: [("one", "1"), ("two", "2")]),
-            registry.makeGauge(name: "g", labels: [("two", "2"), ("one", "1")])
-        )
-        XCTAssertIdentical(
-            registry.makeDurationHistogram(name: "d", labels: [("one", "1"), ("two", "2")], buckets: []),
-            registry.makeDurationHistogram(name: "d", labels: [("two", "2"), ("one", "1")], buckets: [])
-        )
-        XCTAssertIdentical(
-            registry.makeValueHistogram(name: "v", labels: [("one", "1"), ("two", "2")], buckets: []),
-            registry.makeValueHistogram(name: "v", labels: [("two", "2"), ("one", "1")], buckets: [])
+            registry.makeValueHistogram(name: "v", attributes: Set([("one", "1")]), buckets: []),
+            registry.makeValueHistogram(name: "v", attributes: Set([("one", "1")]), buckets: [])
         )
     }
 
@@ -122,20 +102,20 @@ final class OTelMetricRegistryTests: XCTestCase {
     func test_identity_sameNameSameLabelKeysDifferentValues_distinct() {
         let registry = OTelMetricRegistry()
         XCTAssertNotIdentical(
-            registry.makeCounter(name: "c", labels: [("x", "1"), ("y", "2")]),
-            registry.makeCounter(name: "c", labels: [("x", "2"), ("y", "4")])
+            registry.makeCounter(name: "c", attributes: Set([("x", "1"), ("y", "2")])),
+            registry.makeCounter(name: "c", attributes: Set([("x", "2"), ("y", "4")]))
         )
         XCTAssertNotIdentical(
-            registry.makeGauge(name: "g", labels: [("x", "1"), ("y", "2")]),
-            registry.makeGauge(name: "g", labels: [("x", "2"), ("y", "4")])
+            registry.makeGauge(name: "g", attributes: Set([("x", "1"), ("y", "2")])),
+            registry.makeGauge(name: "g", attributes: Set([("x", "2"), ("y", "4")]))
         )
         XCTAssertNotIdentical(
-            registry.makeDurationHistogram(name: "d", labels: [("x", "1"), ("y", "2")], buckets: []),
-            registry.makeDurationHistogram(name: "d", labels: [("x", "2"), ("y", "4")], buckets: [])
+            registry.makeDurationHistogram(name: "d", attributes: Set([("x", "1"), ("y", "2")]), buckets: []),
+            registry.makeDurationHistogram(name: "d", attributes: Set([("x", "2"), ("y", "4")]), buckets: [])
         )
         XCTAssertNotIdentical(
-            registry.makeValueHistogram(name: "v", labels: [("x", "1"), ("y", "2")], buckets: []),
-            registry.makeValueHistogram(name: "v", labels: [("x", "2"), ("y", "4")], buckets: [])
+            registry.makeValueHistogram(name: "v", attributes: Set([("x", "1"), ("y", "2")]), buckets: []),
+            registry.makeValueHistogram(name: "v", attributes: Set([("x", "2"), ("y", "4")]), buckets: [])
         )
     }
 
@@ -143,20 +123,20 @@ final class OTelMetricRegistryTests: XCTestCase {
         let registry = OTelMetricRegistry()
 
         XCTAssertNotIdentical(
-            registry.makeCounter(name: "c", labels: [("x", "1")]),
-            registry.makeCounter(name: "c", labels: [("y", "1")])
+            registry.makeCounter(name: "c", attributes: Set([("x", "1")])),
+            registry.makeCounter(name: "c", attributes: Set([("y", "1")]))
         )
         XCTAssertNotIdentical(
-            registry.makeGauge(name: "g", labels: [("x", "1")]),
-            registry.makeGauge(name: "g", labels: [("y", "1")])
+            registry.makeGauge(name: "g", attributes: Set([("x", "1")])),
+            registry.makeGauge(name: "g", attributes: Set([("y", "1")]))
         )
         XCTAssertNotIdentical(
-            registry.makeDurationHistogram(name: "d", labels: [("x", "1")], buckets: []),
-            registry.makeDurationHistogram(name: "d", labels: [("y", "1")], buckets: [])
+            registry.makeDurationHistogram(name: "d", attributes: Set([("x", "1")]), buckets: []),
+            registry.makeDurationHistogram(name: "d", attributes: Set([("y", "1")]), buckets: [])
         )
         XCTAssertNotIdentical(
-            registry.makeValueHistogram(name: "v", labels: [("x", "1")], buckets: []),
-            registry.makeValueHistogram(name: "v", labels: [("y", "1")], buckets: [])
+            registry.makeValueHistogram(name: "v", attributes: Set([("x", "1")]), buckets: []),
+            registry.makeValueHistogram(name: "v", attributes: Set([("y", "1")]), buckets: [])
         )
     }
 
@@ -164,22 +144,22 @@ final class OTelMetricRegistryTests: XCTestCase {
         let registry = OTelMetricRegistry()
 
         XCTAssertNotIdentical(
-            registry.makeCounter(name: "c", labels: [("x", "1")]),
-            registry.makeCounter(name: "c", labels: [("x", "1"), ("y", "1")])
+            registry.makeCounter(name: "c", attributes: Set([("x", "1")])),
+            registry.makeCounter(name: "c", attributes: Set([("x", "1"), ("y", "1")]))
         )
 
         XCTAssertNotIdentical(
-            registry.makeGauge(name: "g", labels: [("x", "1")]),
-            registry.makeGauge(name: "g", labels: [("x", "1"), ("y", "1")])
+            registry.makeGauge(name: "g", attributes: Set([("x", "1")])),
+            registry.makeGauge(name: "g", attributes: Set([("x", "1"), ("y", "1")]))
         )
 
         XCTAssertNotIdentical(
-            registry.makeDurationHistogram(name: "d", labels: [("x", "1")], buckets: []),
-            registry.makeDurationHistogram(name: "d", labels: [("x", "1"), ("y", "1")], buckets: [])
+            registry.makeDurationHistogram(name: "d", attributes: Set([("x", "1")]), buckets: []),
+            registry.makeDurationHistogram(name: "d", attributes: Set([("x", "1"), ("y", "1")]), buckets: [])
         )
         XCTAssertNotIdentical(
-            registry.makeValueHistogram(name: "v", labels: [("x", "1")], buckets: []),
-            registry.makeValueHistogram(name: "v", labels: [("x", "1"), ("y", "1")], buckets: [])
+            registry.makeValueHistogram(name: "v", attributes: Set([("x", "1")]), buckets: []),
+            registry.makeValueHistogram(name: "v", attributes: Set([("x", "1"), ("y", "1")]), buckets: [])
         )
     }
 
@@ -187,12 +167,12 @@ final class OTelMetricRegistryTests: XCTestCase {
         let registry = OTelMetricRegistry()
 
         XCTAssertIdentical(
-            registry.makeDurationHistogram(name: "d", labels: [("x", "1")], buckets: [.seconds(1)]),
-            registry.makeDurationHistogram(name: "d", labels: [("x", "1")], buckets: [.seconds(2)])
+            registry.makeDurationHistogram(name: "d", attributes: Set([("x", "1")]), buckets: [.seconds(1)]),
+            registry.makeDurationHistogram(name: "d", attributes: Set([("x", "1")]), buckets: [.seconds(2)])
         )
         XCTAssertIdentical(
-            registry.makeValueHistogram(name: "v", labels: [("x", "1")], buckets: [1]),
-            registry.makeValueHistogram(name: "v", labels: [("x", "1")], buckets: [2])
+            registry.makeValueHistogram(name: "v", attributes: Set([("x", "1")]), buckets: [1]),
+            registry.makeValueHistogram(name: "v", attributes: Set([("x", "1")]), buckets: [2])
         )
     }
 
@@ -204,47 +184,47 @@ final class OTelMetricRegistryTests: XCTestCase {
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 0)
 
         // Registering a new metric does not invoke handler.
-        _ = registry.makeCounter(name: "name", labels: [("x", "1")])
+        _ = registry.makeCounter(name: "name", attributes: Set([("x", "1")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 0)
 
         // Registering the same metric does not invoke handler.
-        _ = registry.makeCounter(name: "name", labels: [("x", "1")])
+        _ = registry.makeCounter(name: "name", attributes: Set([("x", "1")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 0)
 
         // Registering a metric with the same identifying fields but different attributes does not invoke handler.
-        _ = registry.makeCounter(name: "name", labels: [("y", "2")])
+        _ = registry.makeCounter(name: "name", attributes: Set([("y", "2")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 0)
 
         // Registring a metric of the same type but with a different identifying field invokes the handler once only.
-        _ = registry.makeCounter(name: "name", unit: "new_unit", labels: [("x", "1")])
+        _ = registry.makeCounter(name: "name", unit: "new_unit", attributes: Set([("x", "1")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 1)
-        _ = registry.makeCounter(name: "name", unit: "new_unit", labels: [("x", "1")])
+        _ = registry.makeCounter(name: "name", unit: "new_unit", attributes: Set([("x", "1")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 1)
 
         // OTel spec also states that description is also an identifying field.
-        _ = registry.makeCounter(name: "name", unit: "new_unit", description: "new description", labels: [("x", "1")])
+        _ = registry.makeCounter(name: "name", unit: "new_unit", description: "new description", attributes: Set([("x", "1")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 2)
-        _ = registry.makeCounter(name: "name", unit: "new_unit", description: "new description", labels: [("x", "1")])
+        _ = registry.makeCounter(name: "name", unit: "new_unit", description: "new description", attributes: Set([("x", "1")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 2)
 
         // The kind of instrument is, of course, also an identifying field.
-        _ = registry.makeGauge(name: "name", labels: [("x", "1")])
+        _ = registry.makeGauge(name: "name", attributes: Set([("x", "1")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 3)
-        _ = registry.makeGauge(name: "name", labels: [("x", "1")])
+        _ = registry.makeGauge(name: "name", attributes: Set([("x", "1")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 3)
 
         // Same for histogram...
-        _ = registry.makeValueHistogram(name: "name", labels: [("x", "1")], buckets: [1])
+        _ = registry.makeValueHistogram(name: "name", attributes: Set([("x", "1")]), buckets: [1])
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 4)
-        _ = registry.makeValueHistogram(name: "name", labels: [("x", "1")], buckets: [1])
+        _ = registry.makeValueHistogram(name: "name", attributes: Set([("x", "1")]), buckets: [1])
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 4)
 
         // ...but currently we do _not_ consider the buckets to be identifying.
-        _ = registry.makeValueHistogram(name: "name", labels: [("x", "1")], buckets: [2])
+        _ = registry.makeValueHistogram(name: "name", attributes: Set([("x", "1")]), buckets: [2])
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 4)
 
         // While name is an identifying field, it is treated case-insensitively.
-        _ = registry.makeCounter(name: "NaMe", labels: [("x", "1")])
+        _ = registry.makeCounter(name: "NaMe", attributes: Set([("x", "1")]))
         XCTAssertEqual(handler.invocations.withLockedValue { $0.count }, 4)
     }
 
@@ -265,19 +245,19 @@ final class OTelMetricRegistryTests: XCTestCase {
         let duplicateRegistrationHandler = RecordingDuplicateRegistrationHandler()
         let registry = OTelMetricRegistry(duplicateRegistrationHandler: duplicateRegistrationHandler)
 
-        registry.unregisterCounter(registry.makeCounter(name: "name", labels: [("a", "1")]))
-        registry.unregisterCounter(registry.makeCounter(name: "name", labels: [("b", "1")]))
+        registry.unregisterCounter(registry.makeCounter(name: "name", attributes: Set([("a", "1")])))
+        registry.unregisterCounter(registry.makeCounter(name: "name", attributes: Set([("b", "1")])))
 
-        registry.unregisterGauge(registry.makeGauge(name: "name", labels: [("a", "1")]))
-        registry.unregisterGauge(registry.makeGauge(name: "name", labels: [("b", "1")]))
+        registry.unregisterGauge(registry.makeGauge(name: "name", attributes: Set([("a", "1")])))
+        registry.unregisterGauge(registry.makeGauge(name: "name", attributes: Set([("b", "1")])))
 
-        registry.unregisterDurationHistogram(registry.makeDurationHistogram(name: "name", labels: [("a", "1")], buckets: []))
-        registry.unregisterDurationHistogram(registry.makeDurationHistogram(name: "name", labels: [("b", "1")], buckets: []))
+        registry.unregisterDurationHistogram(registry.makeDurationHistogram(name: "name", attributes: Set([("a", "1")]), buckets: []))
+        registry.unregisterDurationHistogram(registry.makeDurationHistogram(name: "name", attributes: Set([("b", "1")]), buckets: []))
 
-        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", labels: [("a", "1")], buckets: []))
-        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", labels: [("b", "1")], buckets: []))
+        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", attributes: Set([("a", "1")]), buckets: []))
+        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", attributes: Set([("b", "1")]), buckets: []))
 
-        _ = registry.makeCounter(name: "name", labels: [("a", "1")])
+        _ = registry.makeCounter(name: "name", attributes: Set([("a", "1")]))
 
         XCTAssertEqual(duplicateRegistrationHandler.invocations.withLockedValue { $0 }.count, 0)
     }
@@ -287,17 +267,17 @@ final class OTelMetricRegistryTests: XCTestCase {
         XCTAssertEqual(registry.numDistinctInstruments, 0)
         _ = registry.makeCounter(name: "c1")
         _ = registry.makeCounter(name: "c1")
-        _ = registry.makeCounter(name: "c1", labels: [])
-        _ = registry.makeCounter(name: "c1", labels: [])
+        _ = registry.makeCounter(name: "c1", attributes: Set([]))
+        _ = registry.makeCounter(name: "c1", attributes: Set([]))
         XCTAssertEqual(registry.numDistinctInstruments, 1)
-        _ = registry.makeCounter(name: "c1", labels: [("x", "1")])
-        _ = registry.makeCounter(name: "c1", labels: [("x", "1")])
+        _ = registry.makeCounter(name: "c1", attributes: Set([("x", "1")]))
+        _ = registry.makeCounter(name: "c1", attributes: Set([("x", "1")]))
         XCTAssertEqual(registry.numDistinctInstruments, 2)
-        _ = registry.makeCounter(name: "c1", labels: [("x", "2")])
-        _ = registry.makeCounter(name: "c1", labels: [("x", "2")])
+        _ = registry.makeCounter(name: "c1", attributes: Set([("x", "2")]))
+        _ = registry.makeCounter(name: "c1", attributes: Set([("x", "2")]))
         XCTAssertEqual(registry.numDistinctInstruments, 3)
-        _ = registry.makeCounter(name: "c1", labels: [("y", "1")])
-        _ = registry.makeCounter(name: "c1", labels: [("y", "1")])
+        _ = registry.makeCounter(name: "c1", attributes: Set([("y", "1")]))
+        _ = registry.makeCounter(name: "c1", attributes: Set([("y", "1")]))
         XCTAssertEqual(registry.numDistinctInstruments, 4)
         _ = registry.makeCounter(name: "c2")
         _ = registry.makeCounter(name: "c2")
@@ -308,17 +288,17 @@ final class OTelMetricRegistryTests: XCTestCase {
         let registry = OTelMetricRegistry()
         _ = registry.makeGauge(name: "g1")
         _ = registry.makeGauge(name: "g1")
-        _ = registry.makeGauge(name: "g1", labels: [])
-        _ = registry.makeGauge(name: "g1", labels: [])
+        _ = registry.makeGauge(name: "g1", attributes: Set([]))
+        _ = registry.makeGauge(name: "g1", attributes: Set([]))
         XCTAssertEqual(registry.numDistinctInstruments, 1)
-        _ = registry.makeGauge(name: "g1", labels: [("x", "1")])
-        _ = registry.makeGauge(name: "g1", labels: [("x", "1")])
+        _ = registry.makeGauge(name: "g1", attributes: Set([("x", "1")]))
+        _ = registry.makeGauge(name: "g1", attributes: Set([("x", "1")]))
         XCTAssertEqual(registry.numDistinctInstruments, 2)
-        _ = registry.makeGauge(name: "g1", labels: [("x", "2")])
-        _ = registry.makeGauge(name: "g1", labels: [("x", "2")])
+        _ = registry.makeGauge(name: "g1", attributes: Set([("x", "2")]))
+        _ = registry.makeGauge(name: "g1", attributes: Set([("x", "2")]))
         XCTAssertEqual(registry.numDistinctInstruments, 3)
-        _ = registry.makeGauge(name: "g1", labels: [("y", "1")])
-        _ = registry.makeGauge(name: "g1", labels: [("y", "1")])
+        _ = registry.makeGauge(name: "g1", attributes: Set([("y", "1")]))
+        _ = registry.makeGauge(name: "g1", attributes: Set([("y", "1")]))
         XCTAssertEqual(registry.numDistinctInstruments, 4)
         _ = registry.makeGauge(name: "g2")
         _ = registry.makeGauge(name: "g2")
@@ -329,25 +309,25 @@ final class OTelMetricRegistryTests: XCTestCase {
         let registry = OTelMetricRegistry()
         _ = registry.makeValueHistogram(name: "v1", buckets: [])
         _ = registry.makeValueHistogram(name: "v1", buckets: [])
-        _ = registry.makeValueHistogram(name: "v1", labels: [], buckets: [0, 1])
-        _ = registry.makeValueHistogram(name: "v1", labels: [], buckets: [0, 1])
-        _ = registry.makeValueHistogram(name: "v1", labels: [], buckets: [1, 2])
-        _ = registry.makeValueHistogram(name: "v1", labels: [], buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([]), buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([]), buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([]), buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([]), buckets: [1, 2])
         XCTAssertEqual(registry.numDistinctInstruments, 1)
-        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "1")], buckets: [0, 1])
-        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "1")], buckets: [0, 1])
-        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "1")], buckets: [1, 2])
-        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "1")], buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("x", "1")]), buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("x", "1")]), buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("x", "1")]), buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("x", "1")]), buckets: [1, 2])
         XCTAssertEqual(registry.numDistinctInstruments, 2)
-        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "2")], buckets: [0, 1])
-        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "2")], buckets: [0, 1])
-        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "2")], buckets: [1, 2])
-        _ = registry.makeValueHistogram(name: "v1", labels: [("x", "2")], buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("x", "2")]), buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("x", "2")]), buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("x", "2")]), buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("x", "2")]), buckets: [1, 2])
         XCTAssertEqual(registry.numDistinctInstruments, 3)
-        _ = registry.makeValueHistogram(name: "v1", labels: [("y", "1")], buckets: [0, 1])
-        _ = registry.makeValueHistogram(name: "v1", labels: [("y", "1")], buckets: [0, 1])
-        _ = registry.makeValueHistogram(name: "v1", labels: [("y", "1")], buckets: [1, 2])
-        _ = registry.makeValueHistogram(name: "v1", labels: [("y", "1")], buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("y", "1")]), buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("y", "1")]), buckets: [0, 1])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("y", "1")]), buckets: [1, 2])
+        _ = registry.makeValueHistogram(name: "v1", attributes: Set([("y", "1")]), buckets: [1, 2])
         XCTAssertEqual(registry.numDistinctInstruments, 4)
         _ = registry.makeValueHistogram(name: "v2", buckets: [])
         _ = registry.makeValueHistogram(name: "v2", buckets: [])
@@ -358,25 +338,25 @@ final class OTelMetricRegistryTests: XCTestCase {
         let registry = OTelMetricRegistry()
         _ = registry.makeDurationHistogram(name: "d1", buckets: [])
         _ = registry.makeDurationHistogram(name: "d1", buckets: [])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [], buckets: [.seconds(1)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [], buckets: [.seconds(1)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [], buckets: [.seconds(2)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [], buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([]), buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([]), buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([]), buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([]), buckets: [.seconds(2)])
         XCTAssertEqual(registry.numDistinctInstruments, 1)
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "1")], buckets: [.seconds(1)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "1")], buckets: [.seconds(1)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "1")], buckets: [.seconds(2)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "1")], buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("x", "1")]), buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("x", "1")]), buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("x", "1")]), buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("x", "1")]), buckets: [.seconds(2)])
         XCTAssertEqual(registry.numDistinctInstruments, 2)
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "2")], buckets: [.seconds(1)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "2")], buckets: [.seconds(1)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "2")], buckets: [.seconds(2)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("x", "2")], buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("x", "2")]), buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("x", "2")]), buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("x", "2")]), buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("x", "2")]), buckets: [.seconds(2)])
         XCTAssertEqual(registry.numDistinctInstruments, 3)
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("y", "1")], buckets: [.seconds(1)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("y", "1")], buckets: [.seconds(1)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("y", "1")], buckets: [.seconds(2)])
-        _ = registry.makeDurationHistogram(name: "d1", labels: [("y", "1")], buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("y", "1")]), buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("y", "1")]), buckets: [.seconds(1)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("y", "1")]), buckets: [.seconds(2)])
+        _ = registry.makeDurationHistogram(name: "d1", attributes: Set([("y", "1")]), buckets: [.seconds(2)])
         XCTAssertEqual(registry.numDistinctInstruments, 4)
         _ = registry.makeDurationHistogram(name: "d2", buckets: [])
         _ = registry.makeDurationHistogram(name: "d2", buckets: [])
@@ -393,7 +373,6 @@ final class DuplicateRegistrationHandlerTests: XCTestCase {
             newRegistration: .counter(name: "name"),
             existingRegistrations: [.gauge(name: "name"), .histogram(name: "name")]
         )
-        let recordedLogMessages = recordingLogHandler.recordedLogMessages.withLockedValue { $0 }
         XCTAssertEqual(recordingLogHandler.warningCount, 1)
     }
 

--- a/Tests/OTelTests/Metrics/OTelInstrument/CounterMeasurementTests.swift
+++ b/Tests/OTelTests/Metrics/OTelInstrument/CounterMeasurementTests.swift
@@ -56,9 +56,11 @@ final class CounterMeasurementTests: XCTestCase {
         counter.measure().data.assertIsCumulativeSumWithOneValue(.double(200_000))
     }
 
-    func test_measure_measurementIncludesName() {
-        let counter = Counter(name: "my_counter", attributes: [])
+    func test_measure_measurementIncludesIdentifyingFields() {
+        let counter = Counter(name: "my_counter", unit: "bytes", description: "some description", attributes: [])
         XCTAssertEqual(counter.measure().name, "my_counter")
+        XCTAssertEqual(counter.measure().unit, "bytes")
+        XCTAssertEqual(counter.measure().description, "some description")
     }
 
     func test_measure_measurementIncludesLabelsAsAttributes() throws {

--- a/Tests/OTelTests/Metrics/OTelInstrument/GaugeMeasurementTests.swift
+++ b/Tests/OTelTests/Metrics/OTelInstrument/GaugeMeasurementTests.swift
@@ -59,9 +59,11 @@ final class GaugeMeasurementTests: XCTestCase {
         gauge.measure().data.assertIsGaugeWithOneValue(.double(100_000))
     }
 
-    func test_measure_measurementIncludesName() {
-        let gauge = Gauge(name: "my_gauge", attributes: [])
+    func test_measure_measurementIncludesIdentifyingFields() {
+        let gauge = Counter(name: "my_gauge", unit: "bytes", description: "some description", attributes: [])
         XCTAssertEqual(gauge.measure().name, "my_gauge")
+        XCTAssertEqual(gauge.measure().unit, "bytes")
+        XCTAssertEqual(gauge.measure().description, "some description")
     }
 
     func test_measure_measurementIncludesLabelsAsAttributes() throws {

--- a/Tests/OTelTests/Metrics/OTelInstrument/HistogramMeasurementTests.swift
+++ b/Tests/OTelTests/Metrics/OTelInstrument/HistogramMeasurementTests.swift
@@ -88,9 +88,11 @@ final class HistogramMeasurementTests: XCTestCase {
         ])
     }
 
-    func test_measure_measurementIncludesName() {
-        let histogram = DurationHistogram(name: "my_histogram", attributes: [], buckets: [])
+    func test_measure_measurementIncludesIdentifyingFields() {
+        let histogram = DurationHistogram(name: "my_histogram", unit: "bytes", description: "some description", attributes: [], buckets: [])
         XCTAssertEqual(histogram.measure().name, "my_histogram")
+        XCTAssertEqual(histogram.measure().unit, "bytes")
+        XCTAssertEqual(histogram.measure().description, "some description")
     }
 
     func test_measure_measurementIncludesLabelsAsAttributes() throws {

--- a/Tests/OTelTests/Metrics/SwiftMetricsFactory/OTLPMetricsFactoryTests.swift
+++ b/Tests/OTelTests/Metrics/SwiftMetricsFactory/OTLPMetricsFactoryTests.swift
@@ -433,4 +433,34 @@ final class OTLPMetricsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.defaultValueHistogramBuckets, defaultBucketsFromOTelSpec)
         XCTAssertEqual(factory.defaultDurationHistogramBuckets, defaultBucketsFromOTelSpec.map { .milliseconds($0) })
     }
+
+    func test_factoryMethods_extractUnitAndDescriptionFromDimensions() throws {
+        let duplicateRegistrationHandler = RecordingDuplicateRegistrationHandler()
+        let registry = OTelMetricRegistry(duplicateRegistrationHandler: duplicateRegistrationHandler)
+        let factory = OTLPMetricsFactory(registry: registry)
+
+        let c = factory.makeCounter(label: "c", dimensions: [("unit", "s"), ("description", "mumble")])
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.unit, "s")
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.description, "mumble")
+
+        let f = factory.makeFloatingPointCounter(label: "f", dimensions: [("unit", "s"), ("description", "mumble")])
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.unit, "s")
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.description, "mumble")
+
+        let m = factory.makeMeter(label: "m", dimensions: [("unit", "s"), ("description", "mumble")])
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.unit, "s")
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.description, "mumble")
+
+        let r = factory.makeRecorder(label: "r", dimensions: [("unit", "s"), ("description", "mumble")], aggregate: true)
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.unit, "s")
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.description, "mumble")
+
+        let r_ = factory.makeRecorder(label: "g", dimensions: [("unit", "s"), ("description", "mumble")], aggregate: false)
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.unit, "s")
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.description, "mumble")
+
+        let t = factory.makeTimer(label: "t", dimensions: [("unit", "s"), ("description", "mumble")])
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.unit, "s")
+        XCTAssertEqual((c as? IdentifiableInstrument)?.instrumentIdentifier.description, "mumble")
+    }
 }


### PR DESCRIPTION
## Motivation

As part of the effort to provide an OLTP backend for Swift Metrics (see #84), we need to populate the OTLP `unit` and `description` fields but these values are not provided explicitly by users calling the Swift Metrics API, which takes an `dimensions: [(String, String)]` parameter.

After discussion on the linked issue, it was decided that extracting the values for keys `unit` and `description` from the `dimensions` array, if they are present, was the most pragmatic approach to bridge from Swift Metrics to OTLP.

## Modifications

- Extract `unit` and `description` values from `dimensions` and use for the OTLP export.

## Result

If users provide `unit` and/or `description` elements in the `dimensions` array provided through the Swift Metrics API, these will be used for the corresponding identifying fields in the OTLP export.