### PR TITLE
Rework public API (still SPI) for metrics

### DIFF
--- a/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
+++ b/Sources/OTel/Metrics/MetricStore/OTelMetricRegistry.swift
@@ -52,8 +52,10 @@ public final class OTelMetricRegistry: Sendable {
 
     let storage: NIOLockedValueBox<Storage>
 
-    /// A duplicate instrument registration occurs when more than one instrument of the same
-    /// name is created with different _identifying fields_.
+    /// Behavior when a duplicate instrument registration occurs.
+    ///
+    /// A duplicate instrument registration occurs when more than one instrument of the same name is created with
+    /// different _identifying fields_.
     public struct DuplicateRegistrationBehavior: Sendable {
         enum Behavior: Sendable {
             case warn, crash

--- a/Sources/OTel/Metrics/OTelMetricExporter/OTelMetricExporter.swift
+++ b/Sources/OTel/Metrics/OTelMetricExporter/OTelMetricExporter.swift
@@ -13,7 +13,7 @@
 
 /// Exports a batch of metrics.
 ///
-/// - Seealso: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/metrics/sdk.md#metricexporter
+/// - Seealso: [OTel Specification for Metric Exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/metrics/sdk.md#metricexporter)
 @_spi(Metrics)
 public protocol OTelMetricExporter: Sendable {
     /// Export the given batch of metrics.
@@ -35,5 +35,5 @@ public protocol OTelMetricExporter: Sendable {
 /// An error indicating that an exporter has already been shut down but has been asked to export a batch of metrics.
 @_spi(Metrics)
 public struct OTelMetricExporterAlreadyShutDownError: Error {
-    public init() {}
+    package init() {}
 }

--- a/Sources/OTel/Metrics/OTelMetricProducer/OTLPMetricsDataModel.swift
+++ b/Sources/OTel/Metrics/OTelMetricProducer/OTLPMetricsDataModel.swift
@@ -53,7 +53,6 @@ public struct OTelInstrumentationScope: Equatable, Sendable {
     public var droppedAttributeCount: Int32
 }
 
-/// - Seealso: [](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md#metric-points)
 @_spi(Metrics)
 public struct OTelMetricPoint: Equatable, Sendable {
     public var name: String
@@ -68,7 +67,6 @@ public struct OTelMetricPoint: Equatable, Sendable {
     public var data: OTelMetricData
 }
 
-/// - Seealso: [](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md#sums)
 @_spi(Metrics)
 public struct OTelSum: Equatable, Sendable {
     public var points: [OTelNumberDataPoint]
@@ -76,27 +74,23 @@ public struct OTelSum: Equatable, Sendable {
     public var monotonic: Bool
 }
 
-/// - Seealso: [](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md#gauge)
 @_spi(Metrics)
 public struct OTelGauge: Equatable, Sendable {
     public var points: [OTelNumberDataPoint]
 }
 
-/// - Seealso: [](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md#histogram)
 @_spi(Metrics)
 public struct OTelHistogram: Equatable, Sendable {
     public var aggregationTemporality: OTelAggregationTemporailty
     public var points: [OTelHistogramDataPoint]
 }
 
-/// - Seealso: [](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md)
 @_spi(Metrics)
 public struct OTelAttribute: Hashable, Equatable, Sendable {
     public var key: String
     public var value: String
 }
 
-/// - Seealso: [](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md#temporality)
 @_spi(Metrics)
 public enum OTelAggregationTemporailty: Equatable, Sendable {
     case delta
@@ -120,7 +114,6 @@ public struct OTelNumberDataPoint: Equatable, Sendable {
     public var flags: [Flags]
 }
 
-// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md#histogram
 @_spi(Metrics)
 public struct OTelHistogramDataPoint: Equatable, Sendable {
     public struct Bucket: Equatable, Sendable {
@@ -139,9 +132,6 @@ public struct OTelHistogramDataPoint: Equatable, Sendable {
     public var exemplars: [OTelExemplar]
 }
 
-/// An exemplar is a recorded value that associates OpenTelemetry context to a metric event within a Metric. One use case is to allow users to link Trace signals w/ Metrics.
-///
-/// - Seealso: [](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md#exemplars)
 @_spi(Metrics)
 public struct OTelExemplar: Equatable, Sendable {
     var spanID: OTelSpanID?

--- a/Sources/OTel/Metrics/OTelMetricProducer/OTelMetricProducer.swift
+++ b/Sources/OTel/Metrics/OTelMetricProducer/OTelMetricProducer.swift
@@ -14,13 +14,11 @@
 /// A bridge from third-party metric sources, so they can be plugged into an OpenTelemetry MetricReader as a source of
 /// aggregated metric data.
 ///
-/// - Seealso: [](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#metricproducer)
+/// - Seealso: [OTel specification for Metric Producer](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#metricproducer)
 @_spi(Metrics)
 public protocol OTelMetricProducer: Sendable {
     /// Provides metrics from the MetricProducer to the caller.
     ///
     /// - Returns: a batch of metric points.
-    /// - Seealso: [](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#produce-batch)
-    /// - TODO: Consider adding metrics filter parameter (experimental in OTel 1.29.0)
     func produce() -> [OTelMetricPoint]
 }

--- a/Tests/OTelTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
+++ b/Tests/OTelTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
@@ -33,6 +33,7 @@ final class OTelPeriodicExportingMetricsReaderTests: XCTestCase {
             ),
             clock: clock
         )
+        _ = reader.description
         var sleepCalls = clock.sleepCalls.makeAsyncIterator()
         await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {


### PR DESCRIPTION
## Motivation

As part of the effort to provide an OLTP backend for Swift Metrics (see #84), we need to finalise the API surface. After discussion with @slashmo, @ktoso, and @Joannis, it was decided:

  - `struct OTLPMetricsFactory` will need to be the point of config for anything currently configured on the registry.
  - `nameAndLabelSanitizer` should support returning `nil` to drop.
  - `OTLPMetricsFactory` configuration options should move inside a struct to allow defining the factory as a `let` constant.

We also discussed making the `OTelMetricRegistry` internal but having played around with it, I don't think it's the right approach because:

1. Hiding the producer didn't allow us to hide much else because of the other layers that we _do_ want to expose, e.g. the exporter and reader, which depend on the same abstractions, e.g. the datamodel types.
2. We had to introduce a layering violation between the Swift Metrics factory and the would-be internal registry; we should be to cleanly layer Swift Metrics API support on top of a set of composable protocols that make sense in their own right. By removing this one protocol, we remove the ability for folks to plug parts of this library together and benefit from the composable building blocks.

## Modifications

- Make `OTelMetricExporterAlreadyShutDownError.init` package access.
- Move `OTelPeriodicExportingMetricsReader` conformances into extensions.
- Remove TODO comment from `OTelMetricProducer` (not adding filter while it's still experimental in the spec).
- Rename `nameAndLabelSanitizer` to `registrationPreprocessor` and support dropping metrics.
- Move `OTLPMetricsFactory` configuration options into a struct.
- Clean up links to OTel spec in documentation comments.

**NOTE:** At this time I have _not_ removed the SPI marker, which I will defer until we are finished with the API cleanup.

## Result

The API surface is reduced to what we expect to ship for this feature.