### PR TITLE
Move server sample docs to DocC

### DIFF
--- a/Sources/OTel/OTel.docc/otel.md
+++ b/Sources/OTel/OTel.docc/otel.md
@@ -74,6 +74,7 @@ The goal of Swift OTel is to support all three in a way that feels right at home
 ### Sample Code
 
 - <doc:counter-sample>
+- <doc:server-sample>
 
 ### Misc
 


### PR DESCRIPTION
This PR moves the server sample documentation from its README to DocC to align with the counter sample. The README now links to the DocC documentation instead.