### PR TITLE
Fix Swift 6 warnings/errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.9
 import PackageDescription
 
-let sharedSwiftSettings: [SwiftSetting] = [.enableExperimentalFeature("StrictConcurrency")]
+let sharedSwiftSettings: [SwiftSetting] = [.enableExperimentalFeature("StrictConcurrency=complete")]
 
 let package = Package(
     name: "swift-otel",

--- a/Package.swift
+++ b/Package.swift
@@ -104,5 +104,6 @@ let package = Package(
             ],
             swiftSettings: sharedSwiftSettings
         ),
-    ]
+    ],
+    swiftLanguageVersions: [.version("6"), .v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "OTLPGRPC", targets: ["OTLPGRPC"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),

--- a/Sources/OTelTesting/Metrics+TestHelpers.swift
+++ b/Sources/OTelTesting/Metrics+TestHelpers.swift
@@ -36,7 +36,7 @@ extension Histogram {
         count: Int,
         sum: Value,
         buckets: [(bound: Value, count: Int)],
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let state = box.withLockedValue { $0 }
@@ -67,7 +67,7 @@ extension OTelMetricPoint.OTelMetricData {
         return histogram
     }
 
-    package func assertIsCumulativeSumWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #file, line: UInt = #line) {
+    package func assertIsCumulativeSumWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
         guard
             case .sum(let sum) = data,
             sum.monotonic,
@@ -81,7 +81,7 @@ extension OTelMetricPoint.OTelMetricData {
         XCTAssertEqual(point.value, value, file: file, line: line)
     }
 
-    package func assertIsGaugeWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #file, line: UInt = #line) {
+    package func assertIsGaugeWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
         guard
             case .gauge(let gauge) = data,
             gauge.points.count == 1,
@@ -93,7 +93,7 @@ extension OTelMetricPoint.OTelMetricData {
         XCTAssertEqual(point.value, value, file: file, line: line)
     }
 
-    package func assertIsCumulativeHistogramWith(count: Int, sum: Double, buckets: [OTelHistogramDataPoint.Bucket], file: StaticString = #file, line: UInt = #line) {
+    package func assertIsCumulativeHistogramWith(count: Int, sum: Double, buckets: [OTelHistogramDataPoint.Bucket], file: StaticString = #filePath, line: UInt = #line) {
         guard
             case .histogram(let histogram) = data,
             histogram.aggregationTemporality == .cumulative,

--- a/Sources/OTelTesting/OTelInMemoryPropagator.swift
+++ b/Sources/OTelTesting/OTelInMemoryPropagator.swift
@@ -19,12 +19,8 @@ public final class OTelInMemoryPropagator: OTelPropagator, Sendable {
     private let _injectedSpanContexts = NIOLockedValueBox([OTelSpanContext]())
     public var injectedSpanContexts: [OTelSpanContext] { _injectedSpanContexts.withLockedValue { $0 } }
 
-    /*
-     Sendable warning fixed in https://github.com/apple/swift-distributed-tracing/pull/136,
-     since it enables us to use `NIOLockedValueBox([any Sendable])` instead.
-     */
-    private let _extractedCarriers = NIOLockedValueBox([Any]())
-    public var extractedCarriers: [Any] { _extractedCarriers.withLockedValue { $0 } }
+    private let _extractedCarriers = NIOLockedValueBox([any Sendable]())
+    public var extractedCarriers: [any Sendable] { _extractedCarriers.withLockedValue { $0 } }
     private let extractionResult: Result<OTelSpanContext, Error>?
 
     public init(extractionResult: Result<OTelSpanContext, Error>? = nil) {

--- a/Sources/OTelTesting/RecordingMetricExporter.swift
+++ b/Sources/OTelTesting/RecordingMetricExporter.swift
@@ -46,7 +46,7 @@ extension RecordingMetricExporter {
         exportCallCount: Int,
         forceFlushCallCount: Int,
         shutdownCallCount: Int,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let recordedCalls = recordedCalls.withLockedValue { $0 }

--- a/Tests/OTelTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
+++ b/Tests/OTelTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
@@ -228,7 +228,7 @@ final class MockMetricProducer: Sendable, OTelMetricProducer {
         return produceReturnValue.withLockedValue { $0 }
     }
 
-    func assert(produceCallCount: Int, file: StaticString = #file, line: UInt = #line) {
+    func assert(produceCallCount: Int, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(self.produceCallCount.withLockedValue { $0 }, produceCallCount, file: file, line: line)
     }
 }


### PR DESCRIPTION
Now that https://github.com/apple/swift-distributed-tracing/pull/136 was merged, we could eliminate using `Any` in a unit test which caused a compilation error in Swift 6 language mode.

I also fixed all warnings that started appearing when I turned on Swift 6 language mode.