### PR TITLE
Disable Swift 6 language mode since it fails to build on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,6 +104,5 @@ let package = Package(
             ],
             swiftSettings: sharedSwiftSettings
         ),
-    ],
-    swiftLanguageVersions: [.version("6"), .v5]
+    ]
 )


### PR DESCRIPTION
Tests still do not compile with the latest Swift 6.0 snapshot, but the library is useable from other projects.