### PR TITLE
Direct fix for concurrency errors with Swift 6 compiler on Linux

### DIFF
--- a/Sources/OTel/Tracing/Processing/OTelMultiplexSpanProcessor.swift
+++ b/Sources/OTel/Tracing/Processing/OTelMultiplexSpanProcessor.swift
@@ -62,7 +62,7 @@ public actor OTelMultiplexSpanProcessor: OTelSpanProcessor {
         }
     }
 
-    public func forceFlush() async throws {
+    public nonisolated func forceFlush() async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for processor in processors {
                 group.addTask { try await processor.forceFlush() }


### PR DESCRIPTION
 - Added `nonisolated` to functions that access actor members from inside a task group. This compiles with Swift 6 language mode enabled on the Linux snapshot.
 - I suspect that on macOS, the Swift 6 toolchain there (in Xcode 16 Beta) might have upgraded `ThrowingTaskGroup` to be `Sendable`, which is why the code compiled without issues. So, my question is- @ktoso, should we consider this solution until then, or do we know if Swift 6 will officially make `TaskGroup` and `ThrowingTaskGroup` to be `Sendable`? 