### PR TITLE
Make `OTelSamplingResult.init` Public

### DIFF
--- a/Sources/OTel/Tracing/Sampling/OTelSamplingResult.swift
+++ b/Sources/OTel/Tracing/Sampling/OTelSamplingResult.swift
@@ -21,6 +21,11 @@ public struct OTelSamplingResult: Equatable, Sendable {
     /// Additional attributes describing the sampling decision to be included in the span's attributes.
     public let attributes: SpanAttributes
 
+    /// Create a sampling result with the given decision and attributes.
+    ///
+    /// Parameters:
+    ///   - decision: Whether the span should be recorded/sampled.
+    ///   - attributes: Additional attributes describing the sampling decision.
     public init(decision: OTelSamplingResult.Decision, attributes: SpanAttributes = [:]) {
         self.decision = decision
         self.attributes = attributes

--- a/Sources/OTel/Tracing/Sampling/OTelSamplingResult.swift
+++ b/Sources/OTel/Tracing/Sampling/OTelSamplingResult.swift
@@ -21,7 +21,7 @@ public struct OTelSamplingResult: Equatable, Sendable {
     /// Additional attributes describing the sampling decision to be included in the span's attributes.
     public let attributes: SpanAttributes
 
-    init(decision: OTelSamplingResult.Decision, attributes: SpanAttributes = [:]) {
+    public init(decision: OTelSamplingResult.Decision, attributes: SpanAttributes = [:]) {
         self.decision = decision
         self.attributes = attributes
     }


### PR DESCRIPTION
We need to implement our own `OTelSampler`, but currently, this is not possible due to the restricted access to `OTelSamplingResult.init`.

Although there is a workaround using `OTelConstantSampler`, it is not an elegant solution:

```swift
public func samplingResult(
    operationName: String,
    kind: SpanKind,
    traceID: OTelTraceID,
    attributes: SpanAttributes,
    links: [SpanLink],
    parentContext: ServiceContext
) -> OTelSamplingResult {
    // custom logic
    let result: OTelSamplingResult.Decision = ...
    return OTelConstantSampler(decision: result)
        .samplingResult(
            operationName: operationName,
            kind: kind,
            traceID: traceID,
            attributes: attributes,
            links: links,
            parentContext: parentContext
        )
}
```

By making `OTelSamplingResult.init` public, we can create more customized and cleaner implementations of `OTelSampler`.