### PR TITLE
Use updated log method overload in RecordingLogHandler

### DIFF
--- a/Sources/OTLPGRPC/OTLPGRPCEndpoint.swift
+++ b/Sources/OTLPGRPC/OTLPGRPCEndpoint.swift
@@ -25,7 +25,7 @@ struct OTLPGRPCEndpoint: Equatable {
     }
 
     init(urlString: String, isInsecure: Bool?) throws {
-        guard let url = URL(string: urlString) else {
+        guard !urlString.isEmpty, let url = URL(string: urlString) else {
             // TODO: Log
             self = .default
             return

--- a/Sources/OTelTesting/RecordingLogHandler.swift
+++ b/Sources/OTelTesting/RecordingLogHandler.swift
@@ -26,7 +26,15 @@ package struct RecordingLogHandler: LogHandler {
         (recordedLogMessageStream, recordedLogMessageContinuation) = AsyncStream<LogFunctionCall>.makeStream()
     }
 
-    package func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
+    package func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
         recordedLogMessages.withLockedValue { $0.append((level, message, metadata)) }
         counts.withLockedValue { $0[level] = $0[level, default: 0] + 1 }
         recordedLogMessageContinuation.yield((level, message, metadata))

--- a/Sources/OTelTesting/XCTestCase+Linux.swift
+++ b/Sources/OTelTesting/XCTestCase+Linux.swift
@@ -14,7 +14,7 @@
 // Adds the fulfillment(of:) XCTest method on Linux
 // https://github.com/apple/swift-corelibs-xctest/issues/436#issuecomment-1703589930
 
-#if os(Linux)
+#if os(Linux) && swift(<5.10)
     @preconcurrency import XCTest
 
     extension XCTestCase {

--- a/Sources/OTelTesting/XCTestCase+Linux.swift
+++ b/Sources/OTelTesting/XCTestCase+Linux.swift
@@ -15,7 +15,7 @@
 // https://github.com/apple/swift-corelibs-xctest/issues/436#issuecomment-1703589930
 
 #if os(Linux)
-    import XCTest
+    @preconcurrency import XCTest
 
     extension XCTestCase {
         /// Waits on a group of expectations for up to the specified timeout,

--- a/Sources/OTelTesting/XCTestCase+Linux.swift
+++ b/Sources/OTelTesting/XCTestCase+Linux.swift
@@ -15,7 +15,7 @@
 // https://github.com/apple/swift-corelibs-xctest/issues/436#issuecomment-1703589930
 
 #if os(Linux) && swift(<5.10)
-    @preconcurrency import XCTest
+    import XCTest
 
     extension XCTestCase {
         /// Waits on a group of expectations for up to the specified timeout,
@@ -38,7 +38,7 @@
         ///     expectation from hanging the test.
         public func fulfillment(
             of expectations: [XCTestExpectation],
-            timeout: TimeInterval = .infinity,
+            timeout: TimeInterval,
             enforceOrder: Bool = false
         ) async {
             await withCheckedContinuation { continuation in

--- a/Tests/OTelTests/Resource/OTelResourceDetectionTests.swift
+++ b/Tests/OTelTests/Resource/OTelResourceDetectionTests.swift
@@ -97,7 +97,7 @@ final class OTelResourceDetectionTests: XCTestCase {
         await sleeps.next()
         clock.advance(by: .seconds(2))
 
-        await fulfillment(of: [finishExpectation])
+        await fulfillment(of: [finishExpectation], timeout: 0.1)
     }
 
     func test_resource_withServiceNameEnvironmentVariable_addsProvidedServiceName() async {

--- a/Tests/OTelTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
+++ b/Tests/OTelTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
@@ -197,7 +197,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         await sleeps.next()
         await serviceGroup.triggerGracefulShutdown()
 
-        await fulfillment(of: [finishExpectation])
+        await fulfillment(of: [finishExpectation], timeout: 0.1)
 
         let exportedBatches = await exporter.exportedBatches
         XCTAssertEqual(
@@ -245,7 +245,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         // advance past flush timeout
         clock.advance(by: .seconds(2))
 
-        await fulfillment(of: [finishExpectation])
+        await fulfillment(of: [finishExpectation], timeout: 0.1)
 
         let exportedBatches = await exporter.exportedBatches
         XCTAssertTrue(exportedBatches.isEmpty)

--- a/Tests/OTelTests/Tracing/Processing/OTelMultiplexSpanProcessorTests.swift
+++ b/Tests/OTelTests/Tracing/Processing/OTelMultiplexSpanProcessorTests.swift
@@ -80,9 +80,9 @@ final class OTelMultiplexSpanProcessorTests: XCTestCase {
             finishExpectation.fulfill()
         }
 
-        await fulfillment(of: [startExpectation])
+        await fulfillment(of: [startExpectation], timeout: 0.1)
         await serviceGroup.triggerGracefulShutdown()
-        await fulfillment(of: [finishExpectation])
+        await fulfillment(of: [finishExpectation], timeout: 0.1)
 
         let processor1ShutdownCount = await processor1.numberOfShutdowns
         XCTAssertEqual(processor1ShutdownCount, 1)

--- a/Tests/OTelTests/Tracing/Processing/OTelNoOpSpanProcessorTests.swift
+++ b/Tests/OTelTests/Tracing/Processing/OTelNoOpSpanProcessorTests.swift
@@ -32,8 +32,8 @@ final class OTelNoOpSpanProcessorTests: XCTestCase {
             shutDownExpectation.fulfill()
         }
 
-        await fulfillment(of: [startExpectation])
+        await fulfillment(of: [startExpectation], timeout: 0.1)
         await serviceGroup.triggerGracefulShutdown()
-        await fulfillment(of: [shutDownExpectation])
+        await fulfillment(of: [shutDownExpectation], timeout: 0.1)
     }
 }


### PR DESCRIPTION
We started getting a compiler warning from swift-log because our `RecordingLogHandler` satisfied a deprecated protocol requirement. This PR adopts the new requirement, thus eliminating the warning.

- Closes #133