### PR TITLE
Update to swift-w3c-trace-context 1.0.0-beta.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),
-        .package(url: "https://github.com/slashmo/swift-w3c-trace-context.git", from: "1.0.0-beta.1"),
+        .package(url: "https://github.com/slashmo/swift-w3c-trace-context.git", exact: "1.0.0-beta.3"),
 
         // MARK: - OTLP
 

--- a/Sources/OTelTesting/OTelSpanID+Stub.swift
+++ b/Sources/OTelTesting/OTelSpanID+Stub.swift
@@ -15,8 +15,8 @@ import W3CTraceContext
 
 extension SpanID {
     /// A stub span ID for testing with bytes from one to eight.
-    public static let oneToEight = SpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 8))
+    public static let oneToEight = SpanID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8)))
 
     /// A stub span ID for testing with all bytes being zero.
-    public static let allZeroes = SpanID(bytes: (0, 0, 0, 0, 0, 0, 0, 0))
+    public static let allZeroes = SpanID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 0)))
 }

--- a/Sources/OTelTesting/OTelTraceID+Stub.swift
+++ b/Sources/OTelTesting/OTelTraceID+Stub.swift
@@ -15,8 +15,8 @@ import W3CTraceContext
 
 extension TraceID {
     /// A trace ID stub with bytes from one to sixteen.
-    public static let oneToSixteen = TraceID(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+    public static let oneToSixteen = TraceID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)))
 
     /// A trace ID stub with all bytes being zero.
-    public static let allZeroes = TraceID(bytes: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    public static let allZeroes = TraceID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)))
 }

--- a/Tests/OTLPCoreTests/Tracing/OTelFinishedSpanProtoTests.swift
+++ b/Tests/OTLPCoreTests/Tracing/OTelFinishedSpanProtoTests.swift
@@ -56,7 +56,7 @@ final class OTelFinishedSpanProtoTests: XCTestCase {
     }
 
     func test_initProtoSpan_withFinishedSpan_withParentSpanID_setsParentSpanID() {
-        let parentSpanID = SpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 8))
+        let parentSpanID = SpanID.oneToEight
         let span = OTelFinishedSpan.stub(parentSpanID: parentSpanID)
 
         let protoSpan = Opentelemetry_Proto_Trace_V1_Span(span)

--- a/Tests/OTelTests/Context/OTelRandomIDGeneratorTests.swift
+++ b/Tests/OTelTests/Context/OTelRandomIDGeneratorTests.swift
@@ -21,7 +21,7 @@ final class OTelRandomIDGeneratorTests: XCTestCase {
 
         XCTAssertEqual(
             generator.nextTraceID(),
-            TraceID(bytes: (255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255))
+            TraceID(bytes: .init((255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255)))
         )
     }
 
@@ -52,7 +52,7 @@ final class OTelRandomIDGeneratorTests: XCTestCase {
     func test_spanID_witConstantNumberGenerator_returnsConstantSpanID() {
         let generator = OTelRandomIDGenerator(randomNumberGenerator: ConstantNumberGenerator(value: .max))
 
-        XCTAssertEqual(generator.nextSpanID(), SpanID(bytes: (255, 255, 255, 255, 255, 255, 255, 255)))
+        XCTAssertEqual(generator.nextSpanID(), SpanID(bytes: .init((255, 255, 255, 255, 255, 255, 255, 255))))
     }
 
     func test_spanID_withConstantNumberGenerator_withRandomNumber_returnsRandomSpanID() {

--- a/Tests/OTelTests/Tracing/Propagating/OTelMultiplexPropagatorTests.swift
+++ b/Tests/OTelTests/Tracing/Propagating/OTelMultiplexPropagatorTests.swift
@@ -137,8 +137,8 @@ private struct SystemAPropagator: OTelPropagator {
 }
 
 private struct SystemBPropagator: OTelPropagator {
-    static let validTraceID = TraceID(bytes: (16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
-    static let validSpanID = SpanID(bytes: (8, 7, 6, 5, 4, 3, 2, 1))
+    static let validTraceID = TraceID(bytes: .init((16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)))
+    static let validSpanID = SpanID(bytes: .init((8, 7, 6, 5, 4, 3, 2, 1)))
 
     public func extractSpanContext<Carrier, Extract>(
         from carrier: Carrier,


### PR DESCRIPTION
[Swift W3C TraceContext 1.0.0-beta.3](https://github.com/slashmo/swift-w3c-trace-context/releases/tag/1.0.0-beta.3) introduced a breaking change due to "upgrading" the ID bytes from plain tuples to structs, causing the `TraceID`/`SpanID` initializer to change.