### PR TITLE
Set up benchmarks

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,4 +5,5 @@ coverage:
         threshold: 5%
 
 ignore:
-- Sources/OTelTesting
+- "Sources/OTelTesting"
+- "**/*/OTelTracing+Benchmarking.swift"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,73 @@
+name: Benchmark PR vs. main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-benchmark
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Check benchmark regressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Install jemalloc
+        run: sudo apt-get install -y libjemalloc-dev
+
+      - name: Benchmark PR
+        run: |
+          cd Benchmarks
+          swift package --allow-writing-to-directory .benchmarkBaselines/ benchmark baseline update pr
+
+      - name: Benchmark main
+        run: |
+          git switch main
+          cd Benchmarks
+          swift package --allow-writing-to-directory .benchmarkBaselines/ benchmark baseline update main
+
+      - name: Check benchmark delta
+        id: check_delta
+        run: |
+          echo $(date) >> $GITHUB_STEP_SUMMARY
+          echo "BENCHMARK_STATUS=1" >> "$GITHUB_OUTPUT"
+          cd Benchmarks
+          swift package benchmark baseline check main pr --format markdown >> $GITHUB_STEP_SUMMARY
+          echo "BENCHMARK_STATUS=0" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Produce success comment
+        if: ${{ steps.check_delta.outputs.BENCHMARK_STATUS == '0' }}
+        run: |
+          echo 'PRTEST<<EOF' >> $GITHUB_ENV
+          echo "[Pull request benchmark comparison with 'main' run at $(date -Iseconds)](https://github.com/slashmo/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }})" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Produce failure comment
+        if: ${{ steps.check_delta.outputs.BENCHMARK_STATUS != '0' }}
+        run: |
+          echo 'PRTEST<<EOF' >> $GITHUB_ENV
+          echo "[Pull request benchmark comparison with 'main' run at $(date -Iseconds)](https://github.com/slashmo/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }})" >> $GITHUB_ENV
+          echo "_Pull request had performance regressions_" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: ${{ env.PRTEST }}
+          comment_tag: benchmark
+
+      - name: Exit with correct status
+        run: |
+          exit ${{ steps.check_delta.outputs.BENCHMARK_STATUS }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ xcuserdata/
 .protoc-grpc-swift-plugins/
 .protoc-grpc-swift-plugins.download/
 swift-otel-workspace.xcworkspace/
+.benchmarkBaselines

--- a/Benchmarks/Benchmarks/OTelTracing/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/OTelTracing/Benchmarks.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2023 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import Foundation
+
+let benchmarks = {
+    let ciMetrics: [BenchmarkMetric] = [
+        .instructions,
+        .mallocCountTotal,
+    ]
+    let localMetrics = BenchmarkMetric.default
+
+    Benchmark.defaultConfiguration = .init(
+        metrics: ProcessInfo.processInfo.environment["CI"] != nil ? ciMetrics : localMetrics,
+        warmupIterations: 10
+    )
+
+    // MARK: - Benchmarks
+
+    tracerBenchmarks()
+}

--- a/Benchmarks/Benchmarks/OTelTracing/TracerBenchmarks.swift
+++ b/Benchmarks/Benchmarks/OTelTracing/TracerBenchmarks.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2023 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+@_spi(OTelBenchmarking) import OTel
+import ServiceContextModule
+import W3CTraceContext
+
+func tracerBenchmarks() {
+    Benchmark("Starting sampled root spans") { benchmark in
+        let tracer = OTelTracer(
+            idGenerator: OTelRandomIDGenerator(),
+            sampler: OTelConstantSampler(isOn: true),
+            propagator: OTelW3CPropagator(),
+            processor: OTelNoOpSpanProcessor(),
+            environment: [:],
+            resource: OTelResource()
+        )
+
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            blackHole(tracer.startSpan("test"))
+        }
+    }
+
+    Benchmark("Starting sampled child spans") { benchmark in
+        let tracer = OTelTracer(
+            idGenerator: OTelRandomIDGenerator(),
+            sampler: OTelConstantSampler(isOn: true),
+            propagator: OTelW3CPropagator(),
+            processor: OTelNoOpSpanProcessor(),
+            environment: [:],
+            resource: OTelResource()
+        )
+
+        let parentSpanContext = OTelSpanContext.local(
+            traceID: .random(),
+            spanID: .random(),
+            parentSpanID: nil,
+            traceFlags: .sampled,
+            traceState: TraceState()
+        )
+        let parentContext = ServiceContext.withSpanContext(parentSpanContext)
+
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            blackHole(tracer.startSpan("test", context: parentContext))
+        }
+    }
+
+    Benchmark("Starting dropped root spans") { benchmark in
+        let tracer = OTelTracer(
+            idGenerator: OTelRandomIDGenerator(),
+            sampler: OTelConstantSampler(isOn: false),
+            propagator: OTelW3CPropagator(),
+            processor: OTelNoOpSpanProcessor(),
+            environment: [:],
+            resource: OTelResource()
+        )
+
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            blackHole(tracer.startSpan("test"))
+        }
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "swif-otel-benchmarks",
+    platforms: [
+        .macOS(.v13),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.0.0"),
+        .package(path: ".."),
+    ],
+    targets: [
+        .executableTarget(
+            name: "OTelTracing",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "OTel", package: "swift-otel"),
+            ],
+            path: "Benchmarks/OTelTracing",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
+            ]
+        ),
+    ]
+)

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,9 @@ define contents_xcworkspacedata
 	<Group location="container:" name="Examples">
 	$(foreach example,$(EXAMPLES),<FileRef location="group:$(example)"></FileRef>\n)
 	</Group>
+	<Group location="container:Benchmarks" name="Benchmarks">
+		<FileRef location="group:." name="benchmarks"></FileRef>
+	</Group>
 </Workspace>
 endef
 export contents_xcworkspacedata

--- a/Sources/OTel/Tracing/OTelFinishedSpan.swift
+++ b/Sources/OTel/Tracing/OTelFinishedSpan.swift
@@ -44,4 +44,28 @@ public struct OTelFinishedSpan: Sendable {
 
     /// The links from this span to other spans.
     public let links: [SpanLink]
+
+    public init(
+        spanContext: OTelSpanContext,
+        operationName: String,
+        kind: SpanKind,
+        status: SpanStatus?,
+        startTimeNanosecondsSinceEpoch: UInt64,
+        endTimeNanosecondsSinceEpoch: UInt64,
+        attributes: SpanAttributes,
+        resource: OTelResource,
+        events: [SpanEvent],
+        links: [SpanLink]
+    ) {
+        self.spanContext = spanContext
+        self.operationName = operationName
+        self.kind = kind
+        self.status = status
+        self.startTimeNanosecondsSinceEpoch = startTimeNanosecondsSinceEpoch
+        self.endTimeNanosecondsSinceEpoch = endTimeNanosecondsSinceEpoch
+        self.attributes = attributes
+        self.resource = resource
+        self.events = events
+        self.links = links
+    }
 }

--- a/Sources/OTel/Tracing/OTelTracing+Benchmarking.swift
+++ b/Sources/OTel/Tracing/OTelTracing+Benchmarking.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2023 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import ServiceContextModule
+
+extension ServiceContext {
+    @_spi(OTelBenchmarking)
+    public static func withSpanContext(_ spanContext: OTelSpanContext) -> Self {
+        var context = ServiceContext.topLevel
+        context.spanContext = spanContext
+        return context
+    }
+}

--- a/Sources/OTel/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
+++ b/Sources/OTel/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
@@ -119,6 +119,7 @@ public actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurre
     private func export(_ batch: some Collection<OTelFinishedSpan> & Sendable) async {
         let batchID = batchID
         self.batchID += 1
+        print(batchID)
 
         var exportLogger = logger
         exportLogger[metadataKey: "batch_id"] = "\(batchID)"

--- a/scripts/validate_format.sh
+++ b/scripts/validate_format.sh
@@ -36,7 +36,7 @@ printf "=> Checking format\n"
 FIRST_OUT="$(git status --porcelain)"
 # swiftformat does not scale so we loop ourselves
 shopt -u dotglob
-find Sources/* Tests/* Examples/* -type d -not -path "*/Generated*" | while IFS= read -r d; do
+find Sources/* Tests/* Examples/* Benchmarks/* -type d -not -path "*/Generated*" | while IFS= read -r d; do
   printf "   * checking $d... "
   out=$(mint run swiftformat -quiet $d 2>&1)
   if [[ $out == *$'\n' ]]; then

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -111,6 +111,7 @@ EOF
     cd "$here/.."
     find . \
       \( \! -path './.build/*' \) -a \
+      \( \! -path './Benchmarks/.build/*' \) -a \
       \( \! -path '*/Generated/*' \) -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) | while read line; do


### PR DESCRIPTION
This PR sets up benchmarking for `swift-otel` using [`ordo-one/package-benchmark`](https://github.com/ordo-one/package-benchmark). Benchmarks are defined in a separate Swift package in the `Benchmarks` folder.