### PR TITLE
chore(print): removed batchID from print log

### DIFF
--- a/Sources/OTel/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
+++ b/Sources/OTel/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
@@ -119,7 +119,6 @@ public actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurre
     private func export(_ batch: some Collection<OTelFinishedSpan> & Sendable) async {
         let batchID = batchID
         self.batchID += 1
-        print(batchID)
 
         var exportLogger = logger
         exportLogger[metadataKey: "batch_id"] = "\(batchID)"


### PR DESCRIPTION
I recently started seeing incremental numbers in the logs of a test application. After spending a few hours debugging, I realized the numbers in the logs were from the swift-otel library.

- Remove batchID from the console. 